### PR TITLE
Improve Shared Library Loading Mechanism

### DIFF
--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -1,17 +1,49 @@
+import sys
+import os
 import ctypes
-
 from ctypes import c_int, c_float, c_char_p, c_void_p, c_bool, POINTER, Structure, Array, c_uint8, c_size_t
-
 import pathlib
-from itertools import chain
 
 # Load the library
-# TODO: fragile, should fix
-_base_path = pathlib.Path(__file__).parent
-(_lib_path,) = chain(
-    _base_path.glob("*.so"), _base_path.glob("*.dylib"), _base_path.glob("*.dll")
-)
-_lib = ctypes.CDLL(str(_lib_path))
+def load_shared_library(lib_base_name):
+    # Determine the file extension based on the platform
+    if sys.platform.startswith("linux"):
+        lib_ext = ".so"
+    elif sys.platform == "darwin":
+        lib_ext = ".dylib"
+    elif sys.platform == "win32":
+        lib_ext = ".dll"
+    else:
+        raise RuntimeError("Unsupported platform")
+
+    # Construct the paths to the possible shared library names
+    _base_path = pathlib.Path(__file__).parent.resolve()
+    # Searching for the library in the current directory under the name "libllama" (default name
+    # for llamacpp) and "llama" (default name for this repo)
+    _lib_paths = [
+        _base_path / f"lib{lib_base_name}{lib_ext}",
+        _base_path / f"{lib_base_name}{lib_ext}"
+    ]
+
+    # Add the library directory to the DLL search path on Windows (if needed)
+    if sys.platform == "win32" and sys.version_info >= (3, 8):
+        os.add_dll_directory(str(_base_path))
+
+    # Try to load the shared library, handling potential errors
+    for _lib_path in _lib_paths:
+        if _lib_path.exists():
+            try:
+                return ctypes.CDLL(str(_lib_path))
+            except Exception as e:
+                raise RuntimeError(f"Failed to load shared library '{_lib_path}': {e}")
+
+    raise FileNotFoundError(f"Shared library with base name '{lib_base_name}' not found")
+
+# Specify the base name of the shared library to load
+lib_base_name = "llama"
+
+# Load the library
+_lib = load_shared_library(lib_base_name)
 
 # C types
 llama_context_p = c_void_p


### PR DESCRIPTION
This pull request refines the shared library loading code by introducing the `load_shared_library` function, which accepts the library's base name (`lib_base_name`) as input. Key improvements include:

1. Automatic determination of the library's file extension based on the operating system (`.so` for Linux, `.dylib` for macOS, `.dll` for Windows). This also solves an issue that occurs when more than one lib exists within the same dir.

2. Flexible library paths: Constructs two paths based on lib_base_name, accommodating slight differences in naming conventions used by `llamacpp` and `llama-cpp-python`.

3. On Windows (Python 3.8+), addition of the library directory to the DLL search path.

4. Attempted loading of the shared library via `ctypes.CDLL` and appropriate error handling, including raising `RuntimeError` for load failures and `FileNotFoundError` for missing libraries.