### PR TITLE
Allow local llama library usage

### DIFF
--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -18,9 +18,12 @@ def _load_shared_library(lib_base_name):
 
     # Construct the paths to the possible shared library names
     _base_path = pathlib.Path(__file__).parent.resolve()
+    _local_path = pathlib.Path.cwd()
     # Searching for the library in the current directory under the name "libllama" (default name
     # for llamacpp) and "llama" (default name for this repo)
     _lib_paths = [
+        _local_path / f"./lib{lib_base_name}{lib_ext}",
+        _local_path / f"./{lib_base_name}{lib_ext}",
         _base_path / f"lib{lib_base_name}{lib_ext}",
         _base_path / f"{lib_base_name}{lib_ext}"
     ]

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -26,6 +26,7 @@ def _load_shared_library(lib_base_name):
     ]
 
     if ("LLAMA_LIB" in os.environ):
+        lib_base_name = os.environ["LLAMA_LIB"]
         _lib_paths = [pathlib.Path(os.environ["LLAMA_LIB"]).resolve()]
 
     # Add the library directory to the DLL search path on Windows (if needed)

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -25,8 +25,8 @@ def _load_shared_library(lib_base_name):
         _base_path / f"{lib_base_name}{lib_ext}"
     ]
 
-    if ("LLAMA_LIB" in os.environ):
-        lib_base_name = os.environ["LLAMA_LIB"]
+    if ("LLAMA_CPP_LIB" in os.environ):
+        lib_base_name = os.environ["LLAMA_CPP_LIB"]
         _lib = pathlib.Path(lib_base_name)
         _base_path = _lib.parent.resolve()
         _lib_paths = [_lib.resolve()]

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -27,7 +27,9 @@ def _load_shared_library(lib_base_name):
 
     if ("LLAMA_LIB" in os.environ):
         lib_base_name = os.environ["LLAMA_LIB"]
-        _lib_paths = [pathlib.Path(os.environ["LLAMA_LIB"]).resolve()]
+        _lib = pathlib.Path(lib_base_name)
+        _base_path = _lib.parent.resolve()
+        _lib_paths = [_lib.resolve()]
 
     # Add the library directory to the DLL search path on Windows (if needed)
     if sys.platform == "win32" and sys.version_info >= (3, 8):

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -18,15 +18,15 @@ def _load_shared_library(lib_base_name):
 
     # Construct the paths to the possible shared library names
     _base_path = pathlib.Path(__file__).parent.resolve()
-    _local_path = pathlib.Path.cwd()
     # Searching for the library in the current directory under the name "libllama" (default name
     # for llamacpp) and "llama" (default name for this repo)
     _lib_paths = [
-        _local_path / f"./lib{lib_base_name}{lib_ext}",
-        _local_path / f"./{lib_base_name}{lib_ext}",
         _base_path / f"lib{lib_base_name}{lib_ext}",
         _base_path / f"{lib_base_name}{lib_ext}"
     ]
+
+    if ("LLAMA_LIB" in os.environ):
+        _lib_paths = [pathlib.Path(os.environ["LLAMA_LIB"]).resolve()]
 
     # Add the library directory to the DLL search path on Windows (if needed)
     if sys.platform == "win32" and sys.version_info >= (3, 8):


### PR DESCRIPTION
Sometimes its nice to try different library versions and different forks of llama etc (given they still use the same api).
This commit adds the local path as the first place to search for llama libraries.
