### PR TITLE
Fixes and Tweaks to Defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,4 +163,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/examples/high_level_api/fastapi_server.py
+++ b/examples/high_level_api/fastapi_server.py
@@ -27,10 +27,10 @@ from sse_starlette.sse import EventSourceResponse
 class Settings(BaseSettings):
     model: str
     n_ctx: int = 2048
-    n_batch: int = 2048
-    n_threads: int = os.cpu_count() or 1
+    n_batch: int = 8
+    n_threads: int = int(os.cpu_count() / 2) or 1
     f16_kv: bool = True
-    use_mlock: bool = True
+    use_mlock: bool = False     # This causes a silent failure on platforms that don't support mlock (e.g. Windows) took forever to figure out...
     embedding: bool = True
     last_n_tokens_size: int = 64
 

--- a/llama_cpp/server/__main__.py
+++ b/llama_cpp/server/__main__.py
@@ -28,9 +28,9 @@ class Settings(BaseSettings):
     model: str
     n_ctx: int = 2048
     n_batch: int = 8
-    n_threads: int = os.cpu_count() or 1
+    n_threads: int = int(os.cpu_count() / 2) or 1
     f16_kv: bool = True
-    use_mlock: bool = True
+    use_mlock: bool = False     # This causes a silent failure on platforms that don't support mlock (e.g. Windows) took forever to figure out...
     embedding: bool = True
     last_n_tokens_size: int = 64
 

--- a/llama_cpp/server/__main__.py
+++ b/llama_cpp/server/__main__.py
@@ -27,7 +27,7 @@ from sse_starlette.sse import EventSourceResponse
 class Settings(BaseSettings):
     model: str
     n_ctx: int = 2048
-    n_batch: int = 2048
+    n_batch: int = 8
     n_threads: int = os.cpu_count() or 1
     f16_kv: bool = True
     use_mlock: bool = True

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     entry_points={"console_scripts": ["llama_cpp.server=llama_cpp.server:main"]},
     install_requires=[
         "typing-extensions>=4.5.0",
+        "pydantic==1.10.7",
     ],
     extras_require={
         "server": ["uvicorn>=0.21.1", "fastapi>=0.95.0", "sse-starlette>=1.3.3"],


### PR DESCRIPTION
Wow. It took awhile to figure out that mlock was silently causing the model to fail without an exception. 😢 haha

It's awesome once I got it working though. I still need to look into where it puts the built library and where it searches for it. I think it's searching in the same directory as the executable, but I might have had to manually move it around to get it happy. Don't know why this is.

Summary:
1. Added `pydantic` as a dependency in `setup.py`. The code was previously throwing errors when `pydantic` was not present.
❗ This might also need to be done for scikit-build. I installed it manually at the very start. You probably know more about the best place to do it.

2. Set the default value of `n_batch` to 8 in both `examples/high_level_api/fastapi_server.py` and `llama_cpp/server/__main__.py`. This replaces the previous default value of 2048.

3. Reduced the default value of `n_threads` to half of the available CPU count in both `examples/high_level_api/fastapi_server.py` and `llama_cpp/server/__main__.py`. This is to protect against locking up the system, and I usually only run 1/3 of available threads. Users can always turn it up, but 100 is kind of shocking. More details in actual code.

4. Disabled the use of `mlock` by default in both `examples/high_level_api/fastapi_server.py` and `llama_cpp/server/__main__.py`. The previous setting was causing silent failures on platforms that don't support `mlock`, such as Windows. We can either check if it's supported on the platform, or allow users to enable manually, but I don't think it's recommended by some people in llama.cpp discussions.

5. Updated `.gitignore` to ignore the `./idea` folder.

------------------------------

For additional info, and just future reference, this is how mlock on an unsupported platform fails.

```log
llama_model_load: loading model from 'D:\models\gpt4all\gpt4all-lora-unfiltered-quantized-llama-nmap.bin' - please wait ...
llama_model_load: n_vocab = 32001
llama_model_load: n_ctx   = 2048
llama_model_load: n_embd  = 4096
llama_model_load: n_mult  = 256
llama_model_load: n_head  = 32
llama_model_load: n_layer = 32
llama_model_load: n_rot   = 128
llama_model_load: f16     = 2
llama_model_load: n_ff    = 11008
llama_model_load: n_parts = 1
llama_model_load: type    = 1
llama_model_load: ggml map size = 4017.70 MB
llama_model_load: ggml ctx size =  81.25 KB
llama_model_load: mem required  = 5809.78 MB (+ 1026.00 MB per state)
llama_model_load: loading tensors from 'D:\models\gpt4all\gpt4all-lora-unfiltered-quantized-llama-nmap.bin'
llama_model_load: model size =  4017.27 MB / num tensors = 291

can't mlock because it's not supported on this system     <------- Here

AVX = 1 | AVX2 = 1 | AVX512 = 0 | FMA = 1 | NEON = 0 | ARM_FMA = 0 | F16C = 1 | FP16_VA = 0 | WASM_SIMD = 0 | BLAS = 0 | SSE3 = 1 | VSX = 0 |
INFO:     Started server process [728180]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://localhost:8000 (Press CTRL+C to quit)
INFO:     ::1:59853 - "GET / HTTP/1.1" 404 Not Found
INFO:     ::1:59853 - "GET /favicon.ico HTTP/1.1" 404 Not Found
INFO:     ::1:59853 - "GET /docs HTTP/1.1" 200 OK
INFO:     ::1:59853 - "GET /openapi.json HTTP/1.1" 200 OK
INFO:     ::1:59854 - "POST /v1/completions HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\uvicorn\protocols\http\httptools_impl.py", line 398, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\uvicorn\middleware\proxy_headers.py", line 45, in __call__
    return await self.app(scope, receive, send)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\fastapi\applications.py", line 276, in __call__
    await super().__call__(scope, receive, send)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\starlette\applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\starlette\middleware\errors.py", line 184, in __call__
    raise exc
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\starlette\middleware\errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\starlette\middleware\cors.py", line 92, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\starlette\middleware\cors.py", line 147, in simple_response
    await self.app(scope, receive, send)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\starlette\middleware\exceptions.py", line 79, in __call__
    raise exc
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\starlette\middleware\exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\fastapi\middleware\asyncexitstack.py", line 21, in __call__
    raise e
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\fastapi\middleware\asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\starlette\routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\starlette\routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\starlette\routing.py", line 66, in app
    response = await func(request)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\fastapi\routing.py", line 237, in app
    raw_response = await run_endpoint_function(
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\fastapi\routing.py", line 165, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\starlette\concurrency.py", line 41, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\anyio\to_thread.py", line 31, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\anyio\_backends\_asyncio.py", line 937, in run_sync_in_worker_thread
    return await future
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\venv\lib\site-packages\anyio\_backends\_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\llama_cpp\server\__main__.py", line 106, in create_completion
    return llama(
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\llama_cpp\llama.py", line 527, in __call__
    return self.create_completion(
  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\llama_cpp\llama.py", line 488, in create_completion
    completion: Completion = next(completion_or_chunks)  # type: ignore

  File "C:\Users\Odin\Documents\GitHub\llama-cpp-python\llama_cpp\llama.py", line 305, in _create_completion
    assert self.ctx is not None    <------- Causes this
```
