### PR TITLE
Use https for the gitmodule instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/llama.cpp"]
 	path = vendor/llama.cpp
-	url = git@github.com:ggerganov/llama.cpp.git
+	url = https://github.com/ggerganov/llama.cpp.git


### PR DESCRIPTION
## Why
The submodule is defined using SSH, which means that you cannot initialize the submodule if you don't have SSH set up. 

I was building `llama-cpp-python` from source inside of a docker container which doesn't have SSH set up and I couldn't clone the submodule.

## How
I just replaced the url in `.gitmodules`, it should have no other side effects!