### PR TITLE
Add UTF-8 Encoding in read_text.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from skbuild import setup
 from pathlib import Path
 
 this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
+long_description = (this_directory / "README.md").read_text(encoding='UTF-8')
 
 setup(
     name="llama_cpp_python",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from skbuild import setup
 from pathlib import Path
 
 this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text(encoding='UTF-8')
+long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="llama_cpp_python",


### PR DESCRIPTION
* When compiling and installing on a Chinese language Windows system, the following error occurs, because the default encoding of the Windows system of Chinese language is "GBK" instead of "UTF-8", and specifying the "UTF-8" encoding directly when reading the file can solve this problem. https://github.com/abetlen/llama-cpp-python/issues/45
```
Traceback (most recent call last):
  File "C:\Users\Xpk22\miniconda3\lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 353, in <module>
    main()
  File "C:\Users\Xpk22\miniconda3\lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 335, in main
    json_out['return_val'] = hook(**hook_input['kwargs'])
  File "C:\Users\Xpk22\miniconda3\lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 118, in get_requires_for_build_wheel
    return hook(config_settings)
  File "C:\Users\Xpk22\AppData\Local\Temp\pip-build-env-vb8urq75\overlay\Lib\site-packages\setuptools\build_meta.py", line 338, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=['wheel'])
  File "C:\Users\Xpk22\AppData\Local\Temp\pip-build-env-vb8urq75\overlay\Lib\site-packages\setuptools\build_meta.py", line 320, in _get_build_requires
    self.run_setup()
  File "C:\Users\Xpk22\AppData\Local\Temp\pip-build-env-vb8urq75\overlay\Lib\site-packages\setuptools\build_meta.py", line 335, in run_setup
    exec(code, locals())
  File "<string>", line 6, in <module>
  File "C:\Users\Xpk22\miniconda3\lib\pathlib.py", line 1267, in read_text
    return f.read()
UnicodeDecodeError: 'gbk' codec can't decode byte 0xa6 in position 4: illegal multibyte sequence
```