### PR TITLE
Update n_batch default to 512 to match upstream llama.cpp

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -37,7 +37,7 @@ class Llama:
         use_mlock: bool = False,
         embedding: bool = False,
         n_threads: Optional[int] = None,
-        n_batch: int = 8,
+        n_batch: int = 512,
         last_n_tokens_size: int = 64,
         lora_base: Optional[str] = None,
         lora_path: Optional[str] = None,


### PR DESCRIPTION
With the llama.cpp [n_batch default now set to 512](https://github.com/ggerganov/llama.cpp/pull/1091) we should update this default here as well. This will make BLAS users happy as their libs and the associated performance improvements will be used by default (llama.cpp only enables BLAS if n_batch >=32).

See https://github.com/abetlen/llama-cpp-python/issues/101 where users had to update n_batch to get cuBLAS to work.