### PR TITLE
Fix UnicodeDecodeError permanently

### DIFF
--- a/examples/low_level_api/low_level_api_chat_cpp.py
+++ b/examples/low_level_api/low_level_api_chat_cpp.py
@@ -96,7 +96,7 @@ specified) expect poor results""", file=sys.stderr)
 
 		print(file=sys.stderr)
 		print(f"system_info: n_threads = {self.params.n_threads} / {cpu_count()} \
-| {llama_cpp.llama_print_system_info().decode('utf8', errors='ignore')}", file=sys.stderr)
+| {llama_cpp.llama_print_system_info().decode('utf8')}", file=sys.stderr)
 
 		# determine the required inference memory per token:
 		if (self.params.mem_test):

--- a/examples/low_level_api/low_level_api_chat_cpp.py
+++ b/examples/low_level_api/low_level_api_chat_cpp.py
@@ -356,10 +356,7 @@ n_keep = {self.params.n_keep}
 	def output(self):
 		self.remaining_tokens = self.params.n_predict
 		for id in self.generate():
-			try:
-				yield llama_cpp.llama_token_to_str(self.ctx, id).decode("utf-8", errors="ignore")
-			except UnicodeDecodeError:
-				pass
+			yield llama_cpp.llama_token_to_str(self.ctx, id).decode("utf-8", errors="ignore")
 
 	# read user input
 	def read_input(self):

--- a/examples/low_level_api/low_level_api_chat_cpp.py
+++ b/examples/low_level_api/low_level_api_chat_cpp.py
@@ -96,7 +96,7 @@ specified) expect poor results""", file=sys.stderr)
 
 		print(file=sys.stderr)
 		print(f"system_info: n_threads = {self.params.n_threads} / {cpu_count()} \
-| {llama_cpp.llama_print_system_info().decode('utf8')}", file=sys.stderr)
+| {llama_cpp.llama_print_system_info().decode('utf8', errors='ignore')}", file=sys.stderr)
 
 		# determine the required inference memory per token:
 		if (self.params.mem_test):
@@ -342,7 +342,7 @@ n_keep = {self.params.n_keep}
 	# return past text
 	def past(self):
 		for id in self.last_n_tokens[-self.n_past:]:
-			yield llama_cpp.llama_token_to_str(self.ctx, id).decode("utf-8")
+			yield llama_cpp.llama_token_to_str(self.ctx, id).decode("utf-8", errors="ignore")
 
 	# write input
 	def input(self, prompt: str):
@@ -356,7 +356,10 @@ n_keep = {self.params.n_keep}
 	def output(self):
 		self.remaining_tokens = self.params.n_predict
 		for id in self.generate():
-			yield llama_cpp.llama_token_to_str(self.ctx, id).decode("utf-8")
+			try:
+				yield llama_cpp.llama_token_to_str(self.ctx, id).decode("utf-8", errors="ignore")
+			except UnicodeDecodeError:
+				pass
 
 	# read user input
 	def read_input(self):

--- a/examples/low_level_api/low_level_api_chat_cpp.py
+++ b/examples/low_level_api/low_level_api_chat_cpp.py
@@ -201,7 +201,7 @@ n_keep = {self.params.n_keep}
 	# tokenize a prompt
 	def _tokenize(self, prompt, bos=True):
 		_arr = (llama_cpp.llama_token * (len(prompt) + 1))()
-		_n = llama_cpp.llama_tokenize(self.ctx, prompt.encode("utf8"), _arr, len(_arr), bos)
+		_n = llama_cpp.llama_tokenize(self.ctx, prompt.encode("utf8", errors="ignore"), _arr, len(_arr), bos)
 		return _arr[:_n]
 
 	def set_color(self, c):

--- a/examples/low_level_api/low_level_api_llama_cpp.py
+++ b/examples/low_level_api/low_level_api_llama_cpp.py
@@ -70,7 +70,7 @@ while remaining_tokens > 0:
     if not input_noecho:
         for id in embd:
             print(
-                llama_cpp.llama_token_to_str(ctx, id).decode("utf-8"),
+                llama_cpp.llama_token_to_str(ctx, id).decode("utf-8", errors="ignore"),
                 end="",
                 flush=True,
             )

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -109,7 +109,7 @@ class Llama:
         )
 
         if self.verbose:
-            print(llama_cpp.llama_print_system_info().decode("utf-8"), file=sys.stderr)
+            print(llama_cpp.llama_print_system_info().decode("utf-8", errors="ignore"), file=sys.stderr)
 
     def tokenize(self, text: bytes) -> List[llama_cpp.llama_token]:
         """Tokenize a string.
@@ -460,7 +460,7 @@ class Llama:
                     "model": self.model_path,
                     "choices": [
                         {
-                            "text": text[start:].decode("utf-8"),
+                            "text": text[start:].decode("utf-8", errors="ignore"),
                             "index": 0,
                             "logprobs": None,
                             "finish_reason": None,
@@ -484,7 +484,7 @@ class Llama:
                 "model": self.model_path,
                 "choices": [
                     {
-                        "text": text[returned_characters:].decode("utf-8"),
+                        "text": text[returned_characters:].decode("utf-8", errors="ignore"),
                         "index": 0,
                         "logprobs": None,
                         "finish_reason": finish_reason,
@@ -496,7 +496,7 @@ class Llama:
         ### HACK
         self._completion_bytes.append(text)
         ###
-        text_str = text.decode("utf-8")
+        text_str = text.decode("utf-8", errors="ignore")
 
         if echo:
             text_str = prompt + text_str
@@ -514,7 +514,7 @@ class Llama:
 
             all_tokens = prompt_tokens + completion_tokens
             all_token_strs = [
-                self.detokenize([token]).decode("utf-8") for token in all_tokens
+                self.detokenize([token]).decode("utf-8", errors="ignore") for token in all_tokens
             ]
             all_logprobs = [
                 [Llama.logit_to_logprob(logit) for logit in row]
@@ -533,7 +533,7 @@ class Llama:
                 )
                 token_logprobs.append(sorted_logprobs[int(token)][0])
                 top_logprob = {
-                    self.detokenize([llama_cpp.llama_token(i)]).decode("utf-8"): logprob
+                    self.detokenize([llama_cpp.llama_token(i)]).decode("utf-8", errors="ignore"): logprob
                     for logprob, i in sorted_logprobs[:logprobs]
                 }
                 top_logprob.update({token_str: sorted_logprobs[int(token)][0]})

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -358,7 +358,7 @@ class Llama:
         if self.verbose:
             llama_cpp.llama_reset_timings(self.ctx)
 
-        tokens = self.tokenize(input.encode("utf-8"))
+        tokens = self.tokenize(input.encode("utf-8", errors="ignore"))
         self.reset()
         self.eval(tokens)
         n_tokens = len(tokens)
@@ -416,7 +416,7 @@ class Llama:
         completion_tokens: List[llama_cpp.llama_token] = []
         # Add blank space to start of prompt to match OG llama tokenizer
         prompt_tokens: List[llama_cpp.llama_token] = self.tokenize(
-            b" " + prompt.encode("utf-8")
+            b" " + prompt.encode("utf-8", errors="ignore")
         )
         text: bytes = b""
         returned_characters: int = 0
@@ -431,7 +431,7 @@ class Llama:
             )
 
         if stop != []:
-            stop_sequences = [s.encode("utf-8") for s in stop]
+            stop_sequences = [s.encode("utf-8", errors="ignore") for s in stop]
         else:
             stop_sequences = []
 

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -463,7 +463,7 @@ class Llama:
             for num,pattern in [(2, 192), (3, 224), (4, 240)]:
                 # Bitwise AND check
                 if (pattern & token == pattern):
-                    multibyte_fix = num
+                    multibyte_fix = num - 1
 
             if self.cache and len(completion_tokens) == 0:
                 if prompt_tokens not in self.cache:

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -358,7 +358,7 @@ class Llama:
         if self.verbose:
             llama_cpp.llama_reset_timings(self.ctx)
 
-        tokens = self.tokenize(input.encode("utf-8", errors="ignore"))
+        tokens = self.tokenize(input.encode("utf-8"))
         self.reset()
         self.eval(tokens)
         n_tokens = len(tokens)
@@ -416,7 +416,7 @@ class Llama:
         completion_tokens: List[llama_cpp.llama_token] = []
         # Add blank space to start of prompt to match OG llama tokenizer
         prompt_tokens: List[llama_cpp.llama_token] = self.tokenize(
-            b" " + prompt.encode("utf-8", errors="ignore")
+            b" " + prompt.encode("utf-8")
         )
         text: bytes = b""
         returned_characters: int = 0
@@ -431,7 +431,7 @@ class Llama:
             )
 
         if stop != []:
-            stop_sequences = [s.encode("utf-8", errors="ignore") for s in stop]
+            stop_sequences = [s.encode("utf-8") for s in stop]
         else:
             stop_sequences = []
 

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -472,7 +472,6 @@ class Llama:
             # Contains multi-byte UTF8
             for k,char in enumerate(all_text[-3:]):
                 k = 3 - k
-                char = int.from_bytes(char, "big")
                 for num,pattern in [(2, 192), (3, 224), (4, 240)]:
                     # Bitwise AND check
                     if (num > k and pattern & char == pattern):

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -24,7 +24,7 @@ def test_llama_patch(monkeypatch):
     monkeypatch.setattr("llama_cpp.llama_cpp.llama_eval", mock_eval)
 
     output_text = " jumps over the lazy dog."
-    output_tokens = llama.tokenize(output_text.encode("utf-8"))
+    output_tokens = llama.tokenize(output_text.encode("utf-8", errors="ignore"))
     token_eos = llama.token_eos()
     n = 0
 


### PR DESCRIPTION
https://docs.python.org/3/library/codecs.html#error-handlers

This detects a multibyte UTF8 character, and doesn't return if its incomplete.
If there otherwise wasn't enough tokens or the model somehow returns invalid bytes, we use errors="ignore" to remove invalid characters.
Ascii example:
> 'German ß, ♬'.encode(encoding='ascii', errors="ignore")
> b'German , '

But there will never be thrown a decode or encode error.



Fixes:
https://github.com/abetlen/llama-cpp-python/issues/36
https://github.com/abetlen/llama-cpp-python/issues/57
https://github.com/abetlen/llama-cpp-python/issues/100
https://github.com/abetlen/llama-cpp-python/issues/116
