### PR TITLE
Load dynamically build libs for Apple Platforms (M1/2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,31 @@
-set(CMAKE_SYSTEM_PROCESSOR "arm64")
-
 cmake_minimum_required(VERSION 3.4...3.22)
 
 project(llama_cpp)
 
-set(BUILD_SHARED_LIBS "On")
-add_subdirectory(vendor/llama.cpp)
-install(
-    TARGETS llama 
-    LIBRARY DESTINATION llama_cpp
-    RUNTIME DESTINATION llama_cpp
-)
+option(FORCE_CMAKE "Force CMake build of Python bindings" OFF)
+
+set(FORCE_CMAKE $ENV{FORCE_CMAKE})
+
+if (UNIX AND NOT FORCE_CMAKE AND NOT APPLE)
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/vendor/llama.cpp/libllama.so
+        COMMAND make libllama.so
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/vendor/llama.cpp
+    )
+    add_custom_target(
+        run ALL
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/vendor/llama.cpp/libllama.so
+    )
+    install(
+        FILES ${CMAKE_CURRENT_SOURCE_DIR}/vendor/llama.cpp/libllama.so
+        DESTINATION llama_cpp
+    )
+else()
+    set(BUILD_SHARED_LIBS "On")
+    add_subdirectory(vendor/llama.cpp)
+    install(
+        TARGETS llama
+        LIBRARY DESTINATION llama_cpp
+        RUNTIME DESTINATION llama_cpp
+    )
+endif(UNIX AND NOT FORCE_CMAKE AND NOT APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,13 @@
+set(CMAKE_SYSTEM_PROCESSOR "arm64")
+
 cmake_minimum_required(VERSION 3.4...3.22)
 
 project(llama_cpp)
 
-option(FORCE_CMAKE "Force CMake build of Python bindings" OFF)
-
-set(FORCE_CMAKE $ENV{FORCE_CMAKE})
-
-if (UNIX AND NOT FORCE_CMAKE)
-    add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/vendor/llama.cpp/libllama.so
-        COMMAND make libllama.so
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/vendor/llama.cpp
-    )
-    add_custom_target(
-        run ALL
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/vendor/llama.cpp/libllama.so
-    )
-    install(
-        FILES ${CMAKE_CURRENT_SOURCE_DIR}/vendor/llama.cpp/libllama.so
-        DESTINATION llama_cpp
-    )
-else()
-    set(BUILD_SHARED_LIBS "On")
-    add_subdirectory(vendor/llama.cpp)
-    install(
-        TARGETS llama 
-        LIBRARY DESTINATION llama_cpp
-        RUNTIME DESTINATION llama_cpp
-    )
-endif(UNIX)
+set(BUILD_SHARED_LIBS "On")
+add_subdirectory(vendor/llama.cpp)
+install(
+    TARGETS llama 
+    LIBRARY DESTINATION llama_cpp
+    RUNTIME DESTINATION llama_cpp
+)

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -22,7 +22,7 @@ def _load_shared_library(lib_base_name):
     if sys.platform.startswith("linux"):
         lib_ext = ".so"
     elif sys.platform == "darwin":
-        lib_ext = ".so"
+        lib_ext = ".dylib"
     elif sys.platform == "win32":
         lib_ext = ".dll"
     else:


### PR DESCRIPTION
On Apple Platforms (including ARM64 M1/2) libs are build dynamically, as per CMakeLists.txt. 

Therefore, they get a different extension that needs to be loaded in llama_cpp.py.

Tested on Apple M1 and M2 Platforms (aarch64) with Apple clang version 14.0.0 (clang-1400.0.29.202)