### PR TITLE
Fixes CMake build warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,4 +28,4 @@ else()
         LIBRARY DESTINATION llama_cpp
         RUNTIME DESTINATION llama_cpp
     )
-endif(UNIX)
+endif(UNIX AND NOT FORCE_CMAKE)


### PR DESCRIPTION
```
CMake Warning (dev) in CMakeLists.txt:
  A logical block opening on the line

    E:/Coding/CLONED/llama-cpp-python/CMakeLists.txt:9 (if)

  closes on the line

    E:/Coding/CLONED/llama-cpp-python/CMakeLists.txt:31 (endif)

  with mis-matching arguments.
This warning is for project developers.  Use -Wno-dev to suppress it.
```