### PR TITLE
feat: make embedding support list of string as input

### DIFF
--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -275,7 +275,7 @@ def create_completion(
 
 class CreateEmbeddingRequest(BaseModel):
     model: Optional[str] = model_field
-    input: str = Field(description="The input to embed.")
+    input: Union[str, List[str]] = Field(description="The input to embed.")
     user: Optional[str]
 
     class Config:


### PR DESCRIPTION
The /v1/embeddings route of OpenAI api allows a string or a list of string as input.
This updates allows the of /v1/embeddings to mimic the OpenAI's one.