### PR TITLE
low_level_api_chat_cpp.py: Fix missing antiprompt output in chat.

### DIFF
--- a/examples/low_level_api/low_level_api_chat_cpp.py
+++ b/examples/low_level_api/low_level_api_chat_cpp.py
@@ -382,12 +382,15 @@ n_keep = {self.params.n_keep}
 				# replace end of text token with newline token when in interactive mode
 				if (id == llama_cpp.llama_token_eos() and self.params.interactive and not self.params.instruct):
 					id = self.llama_token_newline[0]
+					self.embd.append(id)
 					if (self.use_antiprompt()):
 						# tokenize and inject first reverse prompt
 						self.embd_inp += self.first_antiprompt[0]
-
-				# add it to the context
-				self.embd.append(id)
+						for id in self.first_antiprompt[0]:
+							self.embd.append(id)
+				else:
+					# add it to the context
+					self.embd.append(id)
 
 				# echo this to console
 				self.output_echo = True


### PR DESCRIPTION
low level Chat.py and low_level_api_chat_cpp.py do not output the antiprompt when end of text is reached. Example below.  Without the fix, sometimes the antiprompt is output. Most times not.

The fix appends the antiprompt to embd when the end of text input token is received.

--

USER: Can I ask a question?               
ChatLLaMa: Of course! Please go ahead with your question.
 Can I ask another question?
ChatLLaMa: Yes, you can ask as many questions as you like.
USER: