### PR TITLE
Add support for `logit_bias` and `logit_bias_type` parameters

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1380,6 +1380,7 @@ class Llama:
         mirostat_tau: float = 5.0,
         mirostat_eta: float = 0.1,
         model: Optional[str] = None,
+        logits_processor: Optional[LogitsProcessorList] = None,
     ) -> Union[ChatCompletion, Iterator[ChatCompletionChunk]]:
         """Generate a chat completion from a list of messages.
 
@@ -1421,6 +1422,7 @@ class Llama:
             mirostat_tau=mirostat_tau,
             mirostat_eta=mirostat_eta,
             model=model,
+            logits_processor=logits_processor,
         )
         if stream:
             chunks: Iterator[CompletionChunk] = completion_or_chunks  # type: ignore

--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -249,13 +249,14 @@ class CreateCompletionRequest(BaseModel):
     )
     presence_penalty: Optional[float] = presence_penalty_field
     frequency_penalty: Optional[float] = frequency_penalty_field
+    logit_bias: Optional[Dict[str, float]] = Field(None)
+    logit_bias_type: Optional[Literal["input_ids", "tokens"]] = Field(None)
 
     # ignored or currently unsupported
     model: Optional[str] = model_field
     n: Optional[int] = 1
     logprobs: Optional[int] = Field(None)
     best_of: Optional[int] = 1
-    logit_bias: Optional[Dict[str, float]] = Field(None)
     user: Optional[str] = Field(None)
 
     # llama.cpp specific parameters
@@ -272,6 +273,39 @@ class CreateCompletionRequest(BaseModel):
 
 
 CreateCompletionResponse = create_model_from_typeddict(llama_cpp.Completion)
+
+
+def make_logit_bias_processor(
+    llama: llama_cpp.Llama,
+    logit_bias: Dict[str, float],
+    logit_bias_type: Optional[Literal["input_ids", "tokens"]],
+):
+    if logit_bias_type is None:
+        logit_bias_type = "input_ids"
+
+    to_bias: Dict[int, float] = {}
+    if logit_bias_type == "input_ids":
+        for input_id, score in logit_bias.items():
+            input_id = int(input_id)
+            to_bias[input_id] = score
+
+    elif logit_bias_type == "tokens":
+        for token, score in logit_bias.items():
+            token = token.encode('utf-8')
+            for input_id in llama.tokenize(token, add_bos=False):
+                to_bias[input_id] = score
+
+    def logit_bias_processor(
+        input_ids: List[int],
+        scores: List[float],
+    ) -> List[float]:
+        new_scores = [None] * len(scores)
+        for input_id, score in enumerate(scores):
+            new_scores[input_id] = score + to_bias.get(input_id, 0.0)
+
+        return new_scores
+
+    return logit_bias_processor
 
 
 @router.post(
@@ -291,9 +325,16 @@ async def create_completion(
         "n",
         "best_of",
         "logit_bias",
+        "logit_bias_type",
         "user",
     }
     kwargs = body.dict(exclude=exclude)
+
+    if body.logit_bias is not None:
+        kwargs['logits_processor'] = llama_cpp.LogitsProcessorList([
+            make_logit_bias_processor(llama, body.logit_bias, body.logit_bias_type),
+        ])
+
     if body.stream:
         send_chan, recv_chan = anyio.create_memory_object_stream(10)
 
@@ -372,11 +413,12 @@ class CreateChatCompletionRequest(BaseModel):
     stream: bool = stream_field
     presence_penalty: Optional[float] = presence_penalty_field
     frequency_penalty: Optional[float] = frequency_penalty_field
+    logit_bias: Optional[Dict[str, float]] = Field(None)
+    logit_bias_type: Optional[Literal["input_ids", "tokens"]] = Field(None)
 
     # ignored or currently unsupported
     model: Optional[str] = model_field
     n: Optional[int] = 1
-    logit_bias: Optional[Dict[str, float]] = Field(None)
     user: Optional[str] = Field(None)
 
     # llama.cpp specific parameters
@@ -413,9 +455,16 @@ async def create_chat_completion(
     exclude = {
         "n",
         "logit_bias",
+        "logit_bias_type",
         "user",
     }
     kwargs = body.dict(exclude=exclude)
+
+    if body.logit_bias is not None:
+        kwargs['logits_processor'] = llama_cpp.LogitsProcessorList([
+            make_logit_bias_processor(llama, body.logit_bias, body.logit_bias_type),
+        ])
+
     if body.stream:
         send_chan, recv_chan = anyio.create_memory_object_stream(10)
 


### PR DESCRIPTION
I was inspired by the way [simpleaichat](https://github.com/minimaxir/simpleaichat/blob/main/PROMPTS.md) works and I wanted to try running it on my own hardware with my own API server. This code relies on the `logit_bias` parameter to work, so I needed to add it.

The way OpenAI's API works is that the `logit_bias` is a mapping from `input_ids` (as a string) to a bias (as a float). Because of the need to use IDs instead of just the token strings themselves, then it means this parameter and its functionality is tied to ChatGPT's tokenizer. This is a problem for other models, obviously.

So in addition to implementing the API as OpenAI intended, I also added another parameter that changes the meaning of `logit_bias` to be a mapping from token strings (as a string) to a bias (as a float).

I tested this with the following pair of requests:

```console
$ curl --verbose --location -H 'Content-Type: application/json' http://localhost:7777/v1/completions --data @<(exec jq --null-input --arg prompt "USER: What is the result of 20+4? ASSISTANT:" 'reduce ( range(0;10) | { (.|tostring): 100.0 } ) as $x ({}; . + $x) | . as $logit_bias | { prompt: $prompt, logit_bias: $logit_bias, logit_bias_type: "tokens", max_tokens: 1 }')

$ curl --verbose --location -H 'Content-Type: application/json' http://localhost:7777/v1/chat/completions --data @<(exec jq --null-input --arg prompt "What is the result of 3+5?" 'reduce ( range(0;10) | { (.|tostring): 100.0 } ) as $x ({}; . + $x) | . as $logit_bias | { messages: [{ "role": "user", "content": $prompt }], logit_bias: $logit_bias, logit_bias_type: "tokens", max_tokens: 1 }')
```

The `jq` commands correspond to the following JSON objects.

```json
{
  "prompt": "USER: What is the result of 20+4? ASSISTANT:",
  "logit_bias": {
    "0": 100,
    "1": 100,
    "2": 100,
    "3": 100,
    "4": 100,
    "5": 100,
    "6": 100,
    "7": 100,
    "8": 100,
    "9": 100
  },
  "logit_bias_type": "tokens",
  "max_tokens": 1
}

{
  "messages": [
    {
      "role": "user",
      "content": "What is the result of 3+5?"
    }
  ],
  "logit_bias": {
    "0": 100,
    "1": 100,
    "2": 100,
    "3": 100,
    "4": 100,
    "5": 100,
    "6": 100,
    "7": 100,
    "8": 100,
    "9": 100
  },
  "logit_bias_type": "tokens",
  "max_tokens": 1
}
```