### PR TITLE
Update llama.py: Added how many input tokens in ValueError exception

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -814,7 +814,7 @@ class Llama:
             llama_cpp.llama_reset_timings(self.ctx)
 
         if len(prompt_tokens) > self._n_ctx:
-            raise ValueError(f"Requested tokens exceed context window of {self._n_ctx}")
+            raise ValueError(f"Requested tokens ({len(prompt_tokens)}) exceed context window of {self._n_ctx}")
 
         # Truncate max_tokens if requested tokens would exceed the context window
         max_tokens = (


### PR DESCRIPTION
Should help understand by how many tokens it exceeds the context size