### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ This package is under active development and I welcome any contributions.
 To get started, clone the repository and install the package in development mode:
 
 ```bash
-git clone --recurse-submodules git@github.com:abetlen/llama-cpp-python.git
+git clone --recurse-submodules https://github.com/abetlen/llama-cpp-python
 
 # Install with pip
 pip install -e .


### PR DESCRIPTION
"git clone git@github.com:abetlen/..." requires access rights to the git account, causing clone failure. 
```
git clone --recurse-submodules git@github.com:abetlen/llama-cpp-python.git
```