### PR TITLE
Create server_streaming.py

### DIFF
--- a/examples/high_level_api/server_streaming.py
+++ b/examples/high_level_api/server_streaming.py
@@ -1,0 +1,31 @@
+import requests
+import json
+
+url = "http://localhost:8000/v1/chat/completions"
+headers = {"accept": "application/json", "Content-Type": "application/json"}
+
+stream = True
+data = {
+    "messages": [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Write me quicksort in Python."},
+    ],
+    "max_tokens": 200,
+    "stream": stream,
+}
+
+response = requests.post(url, headers=headers, json=data, stream=True)
+if not stream:
+    print(response.json()["choices"][0]["message"]["content"])
+else:
+    flag = 0
+    string = []
+    for chunk in response:
+        string.append(chunk.decode("utf-8"))
+        flag += 1
+        if flag % 3 == 0:
+            if string[0].startswith("data:"):
+                delta = json.loads("".join(string)[5:])["choices"][0]["delta"]
+                if delta.get("content", ""):
+                    print(delta["content"], end="", flush=True)
+            string = []


### PR DESCRIPTION
This pull request adds the server_streaming.py example for the high-level API.

The server_streaming.py file is created under the examples/high_level_api/ directory. It contains an implementation of a server streaming example using the high-level API. The code sends messages through an HTTP POST request to "http://localhost:8000/v1/chat/completions" and processes the response. If the stream is set to non-streaming mode, the content of the response will be printed. Otherwise, the code performs streaming processing on the response and prints the parsed content.

This pull request aims to provide a practical example of server streaming using the high-level API, showcasing how to interact with an HTTP server and handle responses.