### PR TITLE
Only concatenate after all batches are done

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -405,6 +405,7 @@ class Llama:
         """
         assert self.ctx is not None
         n_ctx = self._n_ctx
+        scores = []
         for i in range(0, len(tokens), self.n_batch):
             batch = tokens[i : min(len(tokens), i + self.n_batch)]
             n_past = min(n_ctx - len(batch), len(self._input_ids))
@@ -430,9 +431,8 @@ class Llama:
             logits_view = llama_cpp.llama_get_logits(self.ctx)
             logits = [logits_view[i * cols : (i + 1) * cols] for i in range(rows)]
             self.eval_logits.extend(logits)
-            self._scores: npt.NDArray[np.single] = np.concatenate(
-                (self._scores, np.array(logits, dtype=np.single)), axis=0
-            )
+            scores.append(np.array(logits, dtype=np.single))
+        self._scores = np.concatenate(scores)
 
     def _sample(
         self,


### PR DESCRIPTION
Based on the discussion in #398, I was able to make `Llama.eval` faster by only calling `np.concatenate` once all the batches are done.

Performance measurements based on the [tester](https://github.com/abetlen/llama-cpp-python/issues/398#issue-1762827269) included in the original issue.

Master: (~3137.75ms overhead)
```py
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      501    2.977    0.006   87.771    0.175 llama.py:400(eval)
```

This PR: (~350.9ms overhead)
```py
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      501    0.041    0.000   84.657    0.169 llama.py:400(eval)

```