### PR TITLE
Fix incorrect token_logprobs (due to indexing after sorting)

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -958,7 +958,7 @@ class Llama:
                                 )
                             ],
                             "text_offset": [text_offset],
-                            "token_logprobs": [sorted_logprobs[int(token)][0]],
+                            "token_logprobs": [current_logprobs[int(token)]],
                             "top_logprobs": [top_logprob],
                         }
                     returned_tokens += 1
@@ -1033,7 +1033,7 @@ class Llama:
                             self.detokenize([token]).decode("utf-8", errors="ignore")
                         ],
                         "text_offset": [text_offset],
-                        "token_logprobs": [sorted_logprobs[int(token)][0]],
+                        "token_logprobs": [current_logprobs[int(token)]],
                         "top_logprobs": [top_logprob],
                     }
 
@@ -1131,7 +1131,7 @@ class Llama:
                         zip(logprobs_token, range(len(logprobs_token))), reverse=True
                     )
                 )
-                token_logprobs.append(sorted_logprobs[int(token)][0])
+                token_logprobs.append(logprobs_token[int(token)])
                 top_logprob: Optional[Dict[str, float]] = {
                     self.detokenize([i]).decode("utf-8", errors="ignore"): logprob
                     for logprob, i in sorted_logprobs[:logprobs]


### PR DESCRIPTION
Thanks for the wonderful Python wrapper for llama.cpp.
When using your framework, I found a problem in `output['logprobs']['token_logprobs]`.

For example, on commit ca11673 (latest main branch when I write this) the following code
```python
from llama_cpp import Llama
llama = Llama('.../llama.cpp/models/30B/ggml-model-q8_0.bin', logits_all=True)
print(llama('I', temperature=0, max_tokens=5, logprobs=1))
```
will output `{'id': 'cmpl-caa5cef2-ae2f-4157-8323-2dc644bb6308', 'object': 'text_completion', 'created': 1688724957, 'model': '/data/yi/llama.cpp/models/30B/ggml-model-q8_0.bin', 'choices': [{'text': "'m a big fan", 'index': 0, 'logprobs': {'tokens': ["'", 'm', ' a', ' big', ' fan'], 'text_offset': [1, 2, 3, 5, 9], 'token_logprobs': [-19.985351200841283, -19.405950866756548, -7.967424092851152, -12.165255948926252, -17.411318060240337], 'top_logprobs': [{"'": -2.2789093215688228}, {'m': -0.5416520462609419}, {' a': -2.119851766190996}, {' big': -2.872671052838605}, {' fan': -0.29880118020493784}]}, 'finish_reason': 'length'}], 'usage': {'prompt_tokens': 2, 'completion_tokens': 5, 'total_tokens': 7}}`. You can see the `token_logprobs` are quite small, and are different from the numbers in `top_logprobs`, which are assumed to be consistent.

When I look into the code, I find that this unexpected behavior is caused by indexing the sorted logprobs. In L1134 of https://github.com/abetlen/llama-cpp-python/blob/ca11673061ecd9198b4800f68073ae14d4440ecd/llama_cpp/llama.py#L1123-L1140 since `sorted_logprobs` is already sorted, indexing the list by token id does not produce the corresponding logprobs. We should instead index the list before sorting, like the one in L1139.
Same fix for L961 and L1036.

After the fix, on commit 9e61661, the above code outputs `{'id': 'cmpl-74ba65a7-1978-4dcd-aa43-09b35ec8361c', 'object': 'text_completion', 'created': 1688725240, 'model': '/data/yi/llama.cpp/models/30B/ggml-model-q8_0.bin', 'choices': [{'text': "'m a big fan", 'index': 0, 'logprobs': {'tokens': ["'", 'm', ' a', ' big', ' fan'], 'text_offset': [1, 2, 3, 5, 9], 'token_logprobs': [-2.2789093215688228, -0.5416520462609419, -2.119851766190996, -2.872671052838605, -0.29880118020493784], 'top_logprobs': [{"'": -2.2789093215688228}, {'m': -0.5416520462609419}, {' a': -2.119851766190996}, {' big': -2.872671052838605}, {' fan': -0.29880118020493784}]}, 'finish_reason': 'length'}], 'usage': {'prompt_tokens': 2, 'completion_tokens': 5, 'total_tokens': 7}}`, where the `token_logprobs` matches `top_logprobs`.

I think #349 is also due to this bug.