### PR TITLE
Improve GitHub actions

### DIFF
--- a/.github/workflows/test-pypi.yaml
+++ b/.github/workflows/test-pypi.yaml
@@ -3,11 +3,13 @@ name: Tests for PyPI package
 on: workflow_dispatch
 
 jobs:
-  build-linux:
-
-    runs-on: ubuntu-latest
+  pypi-packages-tests:
+    name: ${{ matrix.python-version }} // ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
@@ -19,46 +21,6 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install --verbose llama-cpp-python[server,test]
-      - name: Test with pytest
-        run: |
-          python3 -c "import llama_cpp"
-
-  build-windows:
-
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-
-    steps:
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --verbose llama-cpp-python[server,test]
-      - name: Test with pytest
-        run: |
-          python3 -c "import llama_cpp"
-
-  build-macos:
-
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-
-    steps:
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --verbose llama-cpp-python[server,test]
-      - name: Test with pytest
+      - name: Test import
         run: |
           python3 -c "import llama_cpp"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,11 +9,13 @@ on:
       - main
 
 jobs:
-  build-linux:
-
-    runs-on: ubuntu-latest
+  tests:
+    name: ${{ matrix.python-version }} // ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
@@ -24,56 +26,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip pytest cmake scikit-build setuptools fastapi sse-starlette httpx uvicorn pydantic-settings
-          pip install . -v
+          python -m pip install --upgrade pip poetry
+          poetry install --no-root
+          poetry run pip install '.[server,test]'
       - name: Test with pytest
         run: |
-          pytest
-
-  build-windows:
-
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: "true"
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip pytest cmake scikit-build setuptools fastapi sse-starlette httpx uvicorn pydantic-settings
-          pip install . -v
-      - name: Test with pytest
-        run: |
-          pytest
-
-  build-macos:
-
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: "true"
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip pytest cmake scikit-build setuptools fastapi sse-starlette httpx uvicorn pydantic-settings
-          pip install . -v
-      - name: Test with pytest
-        run: |
-          pytest
+          poetry run pytest


### PR DESCRIPTION
While working on this project, I noticed that there are a few inconsistencies, one of the first being `poetry` being used in the repo but not being used by CI.

This is part of an ongoing attempt to do a bit of a cleanup.

Here are a list of issues I would like to propose some PRs for:
- Drop unneeded dependencies from `pyproject.toml` (e.g. `httpx`)
- Run `black`/`isort`/`prettier` on the whole repository
- Improve type hinting 
- add [`pre-commit`](https://pre-commit.com/)  to run black/isort/prettier for formatting, mypy and ruff for linting, as well as some misc hooks
- clean up build process so that it's done by poetry: this is a bit tricky since this project uses `scikit-build`. `poetry` has an undocumented way of accomplishing this:

```toml
[tool.poetry.build]
script = "build.py
```

Where `build.py` is a custom build script which could call the current `setup.py`

@abetlen would you be ok with me proposing some PRs handling the above? 