### PR TITLE
Add parameter to skip saving to cache when caching is enabled

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -878,6 +878,7 @@ class Llama:
         stopping_criteria: Optional[StoppingCriteriaList] = None,
         logits_processor: Optional[LogitsProcessorList] = None,
         grammar: Optional[LlamaGrammar] = None,
+        save_cache: bool = True
     ) -> Union[Iterator[Completion], Iterator[CompletionChunk]]:
         assert self.ctx is not None
 
@@ -1185,14 +1186,14 @@ class Llama:
                         }
                     ],
                 }
-            if self.cache:
+            if self.cache and save_cache:
                 if self.verbose:
                     print("Llama._create_completion: cache save", file=sys.stderr)
                 self.cache[prompt_tokens + completion_tokens] = self.save_state()
                 print("Llama._create_completion: cache saved", file=sys.stderr)
             return
 
-        if self.cache:
+        if self.cache and save_cache:
             if self.verbose:
                 print("Llama._create_completion: cache save", file=sys.stderr)
             self.cache[prompt_tokens + completion_tokens] = self.save_state()
@@ -1301,6 +1302,7 @@ class Llama:
         stopping_criteria: Optional[StoppingCriteriaList] = None,
         logits_processor: Optional[LogitsProcessorList] = None,
         grammar: Optional[LlamaGrammar] = None,
+        save_cache: bool = True
     ) -> Union[Completion, Iterator[CompletionChunk]]:
         """Generate text from a prompt.
 
@@ -1345,7 +1347,8 @@ class Llama:
             model=model,
             stopping_criteria=stopping_criteria,
             logits_processor=logits_processor,
-            grammar=grammar
+            grammar=grammar,
+            save_cache=save_cache
         )
         if stream:
             chunks: Iterator[CompletionChunk] = completion_or_chunks
@@ -1376,6 +1379,7 @@ class Llama:
         stopping_criteria: Optional[StoppingCriteriaList] = None,
         logits_processor: Optional[LogitsProcessorList] = None,
         grammar: Optional[LlamaGrammar] = None,
+        save_cache: bool = True,
     ) -> Union[Completion, Iterator[CompletionChunk]]:
         """Generate text from a prompt.
 
@@ -1421,6 +1425,7 @@ class Llama:
             stopping_criteria=stopping_criteria,
             logits_processor=logits_processor,
             grammar=grammar,
+            save_cache=save_cache
         )
 
     def _convert_text_completion_to_chat(

--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -484,6 +484,10 @@ mirostat_eta_field = Field(
     default=0.1, ge=0.001, le=1.0, description="Mirostat learning rate"
 )
 
+save_cache_field = Field(
+    default=True, description="Save the result of this completion to cache, if enabled. Defaults to true."
+)
+
 
 class CreateCompletionRequest(BaseModel):
     prompt: Union[str, List[str]] = Field(
@@ -525,6 +529,7 @@ class CreateCompletionRequest(BaseModel):
     top_k: int = top_k_field
     repeat_penalty: float = repeat_penalty_field
     logit_bias_type: Optional[Literal["input_ids", "tokens"]] = Field(None)
+    save_cache: bool = save_cache_field
 
     model_config = {
         "json_schema_extra": {


### PR DESCRIPTION
For some use cases, esp. for apps using LLMs only for specific tasks, there might be a known list of few-shot examples with only the last one always changing according to user input. In such cases, caching the completions every time adds little boost to inference speed, and might actually slow down inference when used with slow memory/disk. Therefore, it is ideal to be able to cache those pre-defined of prompts at the start of the app, and then to skip caching in subsequent calls.

This PR adds a parameter (`save_cache`) to `create_completion()` and other related functions, as well as the completions API in the server. It is set to be `True` by default to avoid changing the default behavior, and is only used when caching is enabled.