### PR TITLE
Add beam search

### DIFF
--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -1456,7 +1456,7 @@ llama_beam_search_callback_fn_t = ctypes.CFUNCTYPE(None, c_void_p, llama_beams_s
 # LLAMA_API void llama_beam_search(struct llama_context * ctx, llama_beam_search_callback_fn_t callback, void * callback_data, size_t n_beams, int n_past, int n_predict, int n_threads);
 def llama_beam_search(
     ctx: llama_context_p,
-    callback: "ctypes._CFuncPtr[None, c_void_p, llama_beams_state]",  # type: ignore
+    callback: llama_beam_search_callback_fn_t,
     callback_data: c_void_p,
     n_beams: Union[c_size_t, int],
     n_past: Union[c_int, int],
@@ -1467,6 +1467,8 @@ def llama_beam_search(
         ctx, callback, callback_data, n_beams, n_past, n_predict, n_threads
     )
 
+_lib.llama_beam_search.argtypes = [llama_context_p, llama_beam_search_callback_fn_t, c_void_p, c_size_t, c_int, c_int, c_int]
+_lib.llama_beam_search.restype = None
 
 # Performance information
 

--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -549,6 +549,7 @@ class CreateCompletionRequest(BaseModel):
     top_k: int = top_k_field
     repeat_penalty: float = repeat_penalty_field
     logit_bias_type: Optional[Literal["input_ids", "tokens"]] = Field(None)
+    beam_width: int = 0
 
     model_config = {
         "json_schema_extra": {

--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -70,7 +70,7 @@ class Settings(BaseSettings):
         default=True, description="if true, use experimental mul_mat_q kernels"
     )
     f16_kv: bool = Field(default=True, description="Whether to use f16 key/value.")
-    logits_all: bool = Field(default=True, description="Whether to return logits.")
+    logits_all: bool = Field(default=False, description="Whether to return logits.")
     vocab_only: bool = Field(
         default=False, description="Whether to only return the vocabulary."
     )


### PR DESCRIPTION
Invoke by adding "beam_width": 2 (for example) to /v1/completions POST.

This PR will be moved out of Draft mode after https://github.com/ggerganov/llama.cpp/pull/2267 is merged. Closes #145 Closes #340 Closes #185 

In the meantime, there is a question:

How does one specify `--logits_all False` when invoked from the command line?
```
python3 -m llama_cpp.server --logits_all False
```
results in `settings.logits_all=True` on startup.