### PR TITLE
Bump llama_tokenize APIs to latest specs

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -430,7 +430,7 @@ class Llama:
         n_tokens = llama_cpp.llama_tokenize_with_model(
             self.model,
             text,
-            len(text)
+            len(text),
             tokens,
             n_ctx,
             add_bos,

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -430,6 +430,7 @@ class Llama:
         n_tokens = llama_cpp.llama_tokenize_with_model(
             self.model,
             text,
+            len(text)
             tokens,
             n_ctx,
             add_bos,
@@ -440,6 +441,7 @@ class Llama:
             n_tokens = llama_cpp.llama_tokenize_with_model(
                 self.model,
                 text,
+                len(text),
                 tokens,
                 n_tokens,
                 add_bos,

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -956,14 +956,22 @@ _lib.llama_token_nl.restype = llama_token
 def llama_tokenize(
     ctx: llama_context_p,
     text: bytes,
+    text_len: Union[c_int, int],
     tokens,  # type: Array[llama_token]
     n_max_tokens: Union[c_int, int],
     add_bos: Union[c_bool, int],
 ) -> int:
-    return _lib.llama_tokenize(ctx, text, tokens, n_max_tokens, add_bos)
+    return _lib.llama_tokenize(ctx, text, text_len, tokens, n_max_tokens, add_bos)
 
 
-_lib.llama_tokenize.argtypes = [llama_context_p, c_char_p, llama_token_p, c_int, c_bool]
+_lib.llama_tokenize.argtypes = [
+    llama_context_p,
+    c_char_p,
+    c_int,
+    llama_token_p,
+    c_int,
+    c_bool,
+]
 _lib.llama_tokenize.restype = c_int
 
 
@@ -976,16 +984,18 @@ _lib.llama_tokenize.restype = c_int
 def llama_tokenize_with_model(
     model: llama_model_p,
     text: bytes,
+    text_len: Union[c_int, int],
     tokens,  # type: Array[llama_token]
     n_max_tokens: Union[c_int, int],
     add_bos: Union[c_bool, bool],
 ) -> int:
-    return _lib.llama_tokenize_with_model(model, text, tokens, n_max_tokens, add_bos)
+    return _lib.llama_tokenize_with_model(model, text, text_len, tokens, n_max_tokens, add_bos)
 
 
 _lib.llama_tokenize_with_model.argtypes = [
     llama_model_p,
     c_char_p,
+    c_int,
     llama_token_p,
     c_int,
     c_bool,


### PR DESCRIPTION
The `llama_tokenize` and `llama_tokenize_with_model` APIs are out-dated with respect to the equivalent APIs in llama.cpp (as shown below):

1. https://github.com/ggerganov/llama.cpp/blob/7ddf185537b712ea0ccbc5f222ee92bed654914e/llama.h#L374
2. https://github.com/ggerganov/llama.cpp/blob/7ddf185537b712ea0ccbc5f222ee92bed654914e/llama.h#L382

ISSUE: Particularly, they are missing an argument `text_len` which denotes the length of the text/prompt being tokenized. This causes segmentation faults, as the wrong arguments get passed on to the C++ library.

This PR adds the required arguments to llama_cpp.py. cc: @abetlen