### PR TITLE
Adds openai-processing-ms response header

### DIFF
--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -1,5 +1,6 @@
 import json
 import multiprocessing
+import time
 from re import compile, Match, Pattern
 from threading import Lock
 from functools import partial
@@ -271,7 +272,11 @@ class RouteErrorHandler(APIRoute):
 
         async def custom_route_handler(request: Request) -> Response:
             try:
-                return await original_route_handler(request)
+                start_sec = time.perf_counter()
+                response = await original_route_handler(request)
+                elapsed_time_ms = int((time.perf_counter() - start_sec) * 1000)
+                response.headers["openai-processing-ms"] = f"{elapsed_time_ms}"
+                return response
             except Exception as exc:
                 json_body = await request.json()
                 try:


### PR DESCRIPTION
Original OpenAI endpoint contains useful header for measuring pure processing time in ms.
![зображення](https://github.com/abetlen/llama-cpp-python/assets/4522842/0062285a-2381-472a-8570-63d322cebd8e)


This helps to avoid additional network delay, geo locality overhead time into final measurements.  