### PR TITLE
fix: recognize `embedding=True` argument

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -841,7 +841,7 @@ class Llama:
         assert self.ctx is not None
         model_name: str = model if model is not None else self.model_path
 
-        if self.model_params.embedding == False:
+        if self.context_params.embedding == False:
             raise RuntimeError(
                 "Llama model must be created with embedding=True to call this method"
             )


### PR DESCRIPTION
seems like we set the `embedding` attribute in `context_params` here:
https://github.com/abetlen/llama-cpp-python/blob/bca965325d236fe68c64d8f063b1887b111d81d8/llama_cpp/llama.py#L342

but try to access it in `model_params` later which always raises an error.