### PR TITLE
Fix #777, #464

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+data/
 .python-version
 
 .vscode/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/llama.cpp"]
-	path = vendor/llama.cpp
-	url = https://github.com/ggerganov/llama.cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,40 +5,16 @@ project(llama_cpp)
 option(LLAMA_BUILD "Build llama.cpp shared library and install alongside python package" ON)
 
 if (LLAMA_BUILD)
-    set(BUILD_SHARED_LIBS "On")
-    if (APPLE AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
-        # Need to disable these llama.cpp flags on Apple x86_64,
-        # otherwise users may encounter invalid instruction errors
-        set(LLAMA_AVX "Off" CACHE BOOL "llama: enable AVX" FORCE)
-        set(LLAMA_AVX2 "Off" CACHE BOOL "llama: enable AVX2" FORCE)
-        set(LLAMA_FMA "Off" CACHE BOOL "llama: enable FMA" FORCE)
-        set(LLAMA_F16C "Off" CACHE BOOL "llama: enable F16C" FORCE)
+    include(ExternalProject)
+    if(NOT DEFINED SKBUILD_PLATLIB_DIR)
+        set(SKBUILD_PLATLIB_DIR ${CMAKE_SOURCE_DIR})
     endif()
-    add_subdirectory(vendor/llama.cpp)
-    install(
-        TARGETS llama 
-        LIBRARY DESTINATION ${SKBUILD_PLATLIB_DIR}/llama_cpp
-        RUNTIME DESTINATION ${SKBUILD_PLATLIB_DIR}/llama_cpp
-        ARCHIVE DESTINATION ${SKBUILD_PLATLIB_DIR}/llama_cpp
-        FRAMEWORK DESTINATION ${SKBUILD_PLATLIB_DIR}/llama_cpp
-        RESOURCE DESTINATION ${SKBUILD_PLATLIB_DIR}/llama_cpp
-    )
-    # Temporary fix for https://github.com/scikit-build/scikit-build-core/issues/374
-    install(
-        TARGETS llama 
-        LIBRARY DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/llama_cpp
-        RUNTIME DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/llama_cpp
-        ARCHIVE DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/llama_cpp
-        FRAMEWORK DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/llama_cpp
-        RESOURCE DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/llama_cpp
-    )
-    # Workaround for Windows + CUDA https://github.com/abetlen/llama-cpp-python/issues/563
-    install(
-        FILES $<TARGET_RUNTIME_DLLS:llama>
-        DESTINATION ${SKBUILD_PLATLIB_DIR}/llama_cpp
-    )
-    install(
-        FILES $<TARGET_RUNTIME_DLLS:llama>
-        DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/llama_cpp
-    )
+    ExternalProject_Add(
+      llama-cpp
+      GIT_REPOSITORY "https://github.com/ggerganov/llama.cpp"
+      GIT_TAG f5ef5cf
+      CMAKE_ARGS -DBUILD_SHARED_LIBS=ON "-DCMAKE_INSTALL_PREFIX=${SKBUILD_PLATLIB_DIR}/llama_cpp/data"
+      USES_TERMINAL_DOWNLOAD 1
+      USES_TERMINAL_CONFIGURE 1
+      USES_TERMINAL_BUILD 1)
 endif()

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -25,7 +25,7 @@ from typing import List, Union
 # Load the library
 def _load_shared_library(lib_base_name: str):
     # Construct the paths to the possible shared library names
-    _base_path = pathlib.Path(os.path.abspath(os.path.dirname(__file__)))
+    _base_path = pathlib.Path(os.path.abspath(os.path.dirname(__file__))) / "data" / "lib"
     # Searching for the library in the current directory under the name "libllama" (default name
     # for llamacpp) and "llama" (default name for this repo)
     _lib_paths: List[pathlib.Path] = []


### PR DESCRIPTION
https://github.com/ggerganov/llama.cpp/pull/3424
Move some code about disabling some flags in Apple x86 to the upstream
Use ExternalProjectAdd() to simplify CMakeLists.txt
Change base_path from llama_cpp to llama_cpp/data like other projects:

- https://github.com/ssciwr/clang-format-wheel/blob/99df0fe0145e0af14c38772f1af78b215456e3a3/CMakeLists.txt#L44
- https://github.com/Freed-Wu/astyle-wheel/blob/340cef6dfd5cfa9158a321fe01b36df6a1e826e8/CMakeLists.txt#L12
- https://github.com/scikit-build/cmake-python-distributions/blob/13473f41061f73e599987af8dee5ba262e065769/setup.py#L46
- https://github.com/scikit-build/ninja-python-distributions/blob/e5510f4f725323b9be845a023bdc164718df1ddd/CMakeLists.txt#L149
