### PR TITLE
Add validation for tensor_split size exceeding LLAMA_MAX_DEVICES

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -308,6 +308,8 @@ class Llama:
         self.tensor_split = tensor_split
         self._p_tensor_split = None
         if self.tensor_split is not None:
+            if len(self.tensor_split) > llama_cpp.LLAMA_MAX_DEVICES:
+                raise ValueError(f"Attempt to split tensors above the maximum supported devices. Current LLAMA_MAX_DEVICES={llama_cpp.LLAMA_MAX_DEVICES}")
             # Type conversion and expand the list to the length of LLAMA_MAX_DEVICES
             FloatArray = ctypes.c_float * llama_cpp.LLAMA_MAX_DEVICES
             self._c_tensor_split = FloatArray(

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -309,7 +309,7 @@ class Llama:
         self._p_tensor_split = None
         if self.tensor_split is not None:
             if len(self.tensor_split) > llama_cpp.LLAMA_MAX_DEVICES:
-                raise ValueError(f"Attempt to split tensors above the maximum supported devices. Current LLAMA_MAX_DEVICES={llama_cpp.LLAMA_MAX_DEVICES}")
+                raise ValueError(f"Attempt to split tensors that exceed maximum supported devices. Current LLAMA_MAX_DEVICES={llama_cpp.LLAMA_MAX_DEVICES}")
             # Type conversion and expand the list to the length of LLAMA_MAX_DEVICES
             FloatArray = ctypes.c_float * llama_cpp.LLAMA_MAX_DEVICES
             self._c_tensor_split = FloatArray(


### PR DESCRIPTION
When GPU acceleration is not properly configured, or some other cases, if the user tries to split tensors into multiple GPUs, **model load** will exit with an exception of
`Could not load Llama model from path: ../models/codellama-7b.Q4_K_M.gguf. Received error invalid index (type=value_error)`
<img width="1051" alt="CleanShot 2023-10-14 at 12 52 26@2x" src="https://github.com/abetlen/llama-cpp-python/assets/10938293/a35616e1-c0dd-40ab-82de-fe56b5f1fb86">

This error message is caused by expanding a python list into a smaller C array `llama.py:312`
<img width="776" alt="CleanShot 2023-10-14 at 12 53 36@2x" src="https://github.com/abetlen/llama-cpp-python/assets/10938293/7191555e-f969-4636-8424-efa6f8f34afa">
However, the error message is misleading, which doesn't contain detail enough information.

Thus this PR captures this case and raise a human-readable exception to point out the situation. Feel free to make any improvements.