### PR TITLE
#823 update value check for n_gpu_layers field

### DIFF
--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -48,8 +48,8 @@ class Settings(BaseSettings):
     )
     n_gpu_layers: int = Field(
         default=0,
-        ge=0,
-        description="The number of layers to put on the GPU. The rest will be on the CPU.",
+        ge=-1,
+        description="The number of layers to put on the GPU. The rest will be on the CPU. Set -1 to move all to GPU.",
     )
     main_gpu: int = Field(
         default=0,


### PR DESCRIPTION
The check for `n_gpu_layers` parameter for the llama_cpp server should be ">=-1".

Closes Issue #823.