### PR TITLE
Do not set `grammar` to `None` for new `LlamaGrammar` objects

### DIFF
--- a/llama_cpp/llama_grammar.py
+++ b/llama_cpp/llama_grammar.py
@@ -57,7 +57,7 @@ class LlamaGrammar:
         )  # type: std.vector[std.vector[LlamaGrammarElement]]
         self._n_rules = self._grammar_rules.size()  # type: int
         self._start_rule_index = parsed_grammar.symbol_ids.at("root")  # type: int
-        self.grammar = self.init()
+        self.init()
 
     @classmethod
     def from_string(cls, grammar: str, verbose: bool = True) -> "LlamaGrammar":

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -1,0 +1,13 @@
+import llama_cpp
+
+tree = """
+leaf ::= "."
+node ::= leaf | "(" node node ")"
+root ::= node
+"""
+
+def test_grammar_from_string():
+    grammar = llama_cpp.LlamaGrammar.from_string(tree)
+    assert grammar._n_rules == 3
+    assert grammar._start_rule_index == 2
+    assert grammar.grammar is not None


### PR DESCRIPTION
The `LlamaGrammar.grammar` attribute is written by `init()`, but that method always returns `None`, so `__init__()` would then discard the previously written object.

Note that `Llama.generate()` will call `LlamaGrammar.reset()` before using the grammar, so it will also work fine without this change, but `Llama.sample()` does not call the `reset()` method.