### PR TITLE
llama: fix exception in Llama.__del__

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1637,12 +1637,14 @@ class Llama:
         )
         return self._convert_completion_to_chat(completion_or_chunks, stream=stream)  # type: ignore
 
-    def _free_model(self):
-        if hasattr(self, "model") and self.model is not None:
-            llama_cpp.llama_free_model(self.model)
+    def _free_model(self, *, _lfree_model=llama_cpp._lib.llama_free_model, _free=llama_cpp._lib.llama_free):
+        model = getattr(self, 'model', None)
+        if model is not None:
+            _lfree_model(model)
             self.model = None
-        if hasattr(self, "ctx") and self.ctx is not None:
-            llama_cpp.llama_free(self.ctx)
+        ctx = getattr(self, 'ctx', None)
+        if ctx is not None:
+            _free(ctx)
             self.ctx = None
 
     def __del__(self):


### PR DESCRIPTION
This fixes an exception that I consistently see with oobabooga's TGWUI:
```
Traceback (most recent call last):
  File "/home/cebtenzzre/src/forks/text-generation-webui/modules/llamacpp_model.py", line 42, in __del__
  File "/home/cebtenzzre/src/forks/llama-cpp-python/llama_cpp/llama.py", line 1720, in __del__
  File "/home/cebtenzzre/src/forks/llama-cpp-python/llama_cpp/llama.py", line 1712, in _free_model
TypeError: 'NoneType' object is not callable
Exception ignored in: <function Llama.__del__ at 0x7f55471987c0>
Traceback (most recent call last):
  File "/home/cebtenzzre/src/forks/llama-cpp-python/llama_cpp/llama.py", line 1720, in __del__
  File "/home/cebtenzzre/src/forks/llama-cpp-python/llama_cpp/llama.py", line 1712, in _free_model
TypeError: 'NoneType' object is not callable
```

\_\_del\_\_ can be tricky to implement because there are few guarantees about what has not already been destroyed. This fix uses a similar approach to what the python stdlib does in deleters.