### PR TITLE
Fix for shared library not found and compile issues in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Then, call `pip` after setting the variables:
 pip install llama-cpp-python
 ```
 
+If you run into issues where it complains it can't find `'nmake'` `'?'` or CMAKE_C_COMPILER, you can extract w64devkit as [mentioned in llama.cpp repo](https://github.com/ggerganov/llama.cpp#openblas) and add those manually to CMAKE_ARGS before running `pip` install:
+```ps
+$env:CMAKE_GENERATOR = "MinGW Makefiles"
+$env:CMAKE_ARGS = "-DLLAMA_OPENBLAS=on -DCMAKE_C_COMPILER=C:/w64devkit/bin/gcc.exe -DCMAKE_CXX_COMPILER=C:/w64devkit/bin/g++.exe" 
+```
+
 See the above instructions and set `CMAKE_ARGS` to the BLAS backend you want to use.
 
 #### MacOS remarks

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -41,7 +41,7 @@ def _load_shared_library(lib_base_name: str):
         ]
     elif sys.platform == "win32":
         _lib_paths += [
-            _base_path / f"{lib_base_name}.dll",
+            _base_path / f"lib{lib_base_name}.dll",
         ]
     else:
         raise RuntimeError("Unsupported platform")

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -41,6 +41,7 @@ def _load_shared_library(lib_base_name: str):
         ]
     elif sys.platform == "win32":
         _lib_paths += [
+            _base_path / f"{lib_base_name}.dll",
             _base_path / f"lib{lib_base_name}.dll",
         ]
     else:


### PR DESCRIPTION
I noticed that the library .dll file that gets installed in python site-packages location is actually libllama.dll while it is trying to look for llama.dll in the code in windows machine. After making this change and reinstalling from source, everything started working fine for me.

Also updated README.md to include some extra info for Windows users trying to build using w64devkit like llama.cpp.

Setup: Windows 10 Pro, Intel CPU i7 12th gen.

Issues related: #568 #825 #751 