### PR TITLE
fix: tokenization of special characters:

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -856,7 +856,7 @@ class Llama:
         data: List[EmbeddingData] = []
         total_tokens = 0
         for index, input in enumerate(inputs):
-            tokens = self.tokenize(input.encode("utf-8"))
+            tokens = self.tokenize(input.encode("utf-8"), special=True)
             self.reset()
             self.eval(tokens)
             n_tokens = len(tokens)
@@ -927,7 +927,7 @@ class Llama:
         completion_tokens: List[int] = []
         # Add blank space to start of prompt to match OG llama tokenizer
         prompt_tokens: List[int] = (
-            self.tokenize(prompt.encode("utf-8"))
+            self.tokenize(prompt.encode("utf-8"), special=True)
             if prompt != ""
             else [self.token_bos()]
         )
@@ -1823,7 +1823,7 @@ class LlamaTokenizer:
 
     def encode(self, text: str, add_bos: bool = True) -> List[int]:
         return self.llama.tokenize(
-            text.encode("utf-8", errors="ignore"), add_bos=add_bos
+            text.encode("utf-8", errors="ignore"), add_bos=add_bos, special=True
         )
 
     def decode(self, tokens: List[int]) -> str:

--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -589,7 +589,7 @@ def make_logit_bias_processor(
     elif logit_bias_type == "tokens":
         for token, score in logit_bias.items():
             token = token.encode("utf-8")
-            for input_id in llama.tokenize(token, add_bos=False):
+            for input_id in llama.tokenize(token, add_bos=False, special=True):
                 to_bias[input_id] = score
 
     def logit_bias_processor(

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -25,6 +25,15 @@ def test_llama_cpp_tokenization():
     detokenized = llama.detokenize(tokens)
     assert detokenized != text
 
+    text = b"Hello World</s>"
+    tokens = llama.tokenize(text)
+    assert tokens[-1] != llama.token_eos()
+    assert tokens == [1, 15043, 2787, 829, 29879, 29958]
+
+    tokens = llama.tokenize(text, special=True)
+    assert tokens[-1] == llama.token_eos()
+    assert tokens == [1, 10994, 2787, 2]
+
 
 def test_llama_patch(monkeypatch):
     llama = llama_cpp.Llama(model_path=MODEL, vocab_only=True)


### PR DESCRIPTION
It should behave like llama.cpp, where most out of the box usages treat special characters accordingly. See https://github.com/abetlen/llama-cpp-python/issues/838#issuecomment-1784966013 for more details.

I checked that with this fix, the vanilla call to `llm.create_completion(temperature=0)` leads to exactly the same results for a simple chat prompt than when using `./main --temp 0` from `llama.cpp` - which it didn't before.

I changed the behaviour also for the embeddings and the LlamaTokenizer. I'm missing context so might be wrong on those, but I figured it would be good to be consistent.

