### PR TITLE
fixed Llama._create_completion suffix check

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -921,6 +921,7 @@ class Llama:
         grammar: Optional[LlamaGrammar] = None,
     ) -> Union[Iterator[Completion], Iterator[CompletionChunk]]:
         assert self.ctx is not None
+        assert suffix is None or suffix.__class__ is str
 
         completion_id: str = f"cmpl-{str(uuid.uuid4())}"
         created: int = int(time.time())


### PR DESCRIPTION
We discovered that it was possible to exploit  `Llama._create_completion` suffix parameter to send string-like object which could actually lead to Arbitrary Code Execution.

Here is PoC: https://github.com/tangledgroup/llama-cpp-python-exploit/blob/f99baf1e66b9fa79987c594179ac93eadfb2ca97/exploit.py#L45