### PR TITLE
fix: openblas_simple missing pkg-config to build

### DIFF
--- a/docker/openblas_simple/Dockerfile
+++ b/docker/openblas_simple/Dockerfile
@@ -6,7 +6,7 @@ ENV HOST 0.0.0.0
 COPY . .
 
 # Install the package
-RUN apt update && apt install -y libopenblas-dev ninja-build build-essential
+RUN apt update && apt install -y libopenblas-dev ninja-build build-essential pkg-config
 RUN python -m pip install --upgrade pip pytest cmake scikit-build setuptools fastapi uvicorn sse-starlette pydantic-settings starlette-context
 
 RUN CMAKE_ARGS="-DLLAMA_BLAS=ON -DLLAMA_BLAS_VENDOR=OpenBLAS" pip install llama_cpp_python --verbose


### PR DESCRIPTION
Adding pkg-config to Dockerfile for openblas_simple