### PR TITLE
Add chat format to support baichuan

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -471,6 +471,23 @@ def format_baichuan2(
     _prompt = _format_no_colon_single(system_message, _messages, _sep)
     return ChatFormatterResponse(prompt=_prompt)
 
+
+@register_chat_format("baichuan")
+def format_baichuan(
+    messages: List[llama_types.ChatCompletionRequestMessage],
+    **kwargs: Any,
+) -> ChatFormatterResponse:
+    _system_template = "{system_message}"
+    _roles = dict(user="<reserved_102>", assistant="<reserved_103>")
+    _sep = ""
+    system_message = _get_system_message(messages)
+    system_message = _system_template.format(system_message=system_message)
+    _messages = _map_roles(messages, _roles)
+    _messages.append((_roles["assistant"], None))
+    _prompt = _format_no_colon_single(system_message, _messages, _sep)
+    return ChatFormatterResponse(prompt=_prompt)
+
+
 @register_chat_format("openbuddy")
 def format_openbuddy(
     messages: List[llama_types.ChatCompletionRequestMessage],


### PR DESCRIPTION
Similar to https://github.com/abetlen/llama-cpp-python/pull/936, but support baichuan 1 (https://huggingface.co/baichuan-inc/Baichuan-13B-Chat)

# How to use it

launch llama-cpp-python server with " --chat_format baichuan"

```
python3 -m llama_cpp.server --model models/baichuan-13b-chat-baichuan-Q3_K_M.gguf --host 0.0.0.0 --port 9000 --n_gpu_layers -1 --chat_format baichuan
```
