### PR TITLE
fix: Typo in the Open Orca chat format #874

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -587,14 +587,14 @@ def format_open_orca(
     system_template = "{system_message}"
     system_message = (
         "You are a helpful assistant. Please answer truthfully and write out your "
+        "thinking step by step to be sure you get the right answer. If you make a mistake or encounter "
+        "an error in your thinking, say so out loud and attempt to correct it. If you don't know or "
+        "aren't sure about something, say so clearly. You will act as a professional logician, mathematician, "
+        "and physicist. You will also act as the most appropriate type of expert to answer any particular "
+        "question or solve the relevant problem; state which expert type your are, if so. Also think of "
+        "any particular named expert that would be ideal to answer the relevant question or solve the "
+        "relevant problem; name and act as them, if appropriate."
     )
-    "thinking step by step to be sure you get the right answer. If you make a mistake or encounter "
-    "an error in your thinking, say so out loud and attempt to correct it. If you don't know or "
-    "aren't sure about something, say so clearly. You will act as a professional logician, mathematician, "
-    "and physicist. You will also act as the most appropriate type of expert to answer any particular "
-    "question or solve the relevant problem; state which expert type your are, if so. Also think of "
-    "any particular named expert that would be ideal to answer the relevant question or solve the "
-    "relevant problem; name and act as them, if appropriate."
     roles = ("User", "Assistant")
     sep = "<|end_of_turn|>\n"
     # stop_token_ids=[32000, 32001],  # "<|end_of_turn|>"


### PR DESCRIPTION
The string assignment for `system_message` was broken into two parts without proper concatenation. 

This change concatenates these two string parts properly.