### PR TITLE
Fix #891

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -214,6 +214,8 @@ class _LlamaModel:
     NOTE: For stability it's recommended you use the Llama class instead."""
 
     _llama_free_model = None
+    # NOTE: this must be "saved" here to avoid exceptions when calling __del__
+    suppress_stdout_stderr = suppress_stdout_stderr
 
     def __init__(
         self,
@@ -237,7 +239,7 @@ class _LlamaModel:
             )
 
     def __del__(self):
-        with suppress_stdout_stderr(disable=self.verbose):
+        with self.suppress_stdout_stderr(disable=self.verbose):
             if self.model is not None and self._llama_free_model is not None:
                 self._llama_free_model(self.model)
                 self.model = None
@@ -399,6 +401,8 @@ class _LlamaContext:
     NOTE: For stability it's recommended you use the Llama class instead."""
 
     _llama_free = None
+    # NOTE: this must be "saved" here to avoid exceptions when calling __del__
+    suppress_stdout_stderr = suppress_stdout_stderr
 
     def __init__(
         self,
@@ -419,7 +423,7 @@ class _LlamaContext:
             )
 
     def __del__(self):
-        with suppress_stdout_stderr(disable=self.verbose):
+        with self.suppress_stdout_stderr(disable=self.verbose):
             if self.ctx is not None and self._llama_free is not None:
                 self._llama_free(self.ctx)
                 self.ctx = None
@@ -650,6 +654,8 @@ class _LlamaContext:
 
 class _LlamaBatch:
     _llama_batch_free = None
+    # NOTE: this must be "saved" here to avoid exceptions when calling __del__
+    suppress_stdout_stderr = suppress_stdout_stderr
 
     def __init__(
         self, *, n_tokens: int, embd: int, n_seq_max: int, verbose: bool = True
@@ -667,7 +673,7 @@ class _LlamaBatch:
             )
 
     def __del__(self):
-        with suppress_stdout_stderr(disable=self.verbose):
+        with self.suppress_stdout_stderr(disable=self.verbose):
             if self.batch is not None and self._llama_batch_free is not None:
                 self._llama_batch_free(self.batch)
                 self.batch = None


### PR DESCRIPTION
Fix https://github.com/abetlen/llama-cpp-python/issues/891

As noted in the [Python docs](https://docs.python.org/3/reference/datamodel.html#object.__del__), objects can get nullified on interpreter shutdown in `__del__`. The solution follows the same pattern [here](https://github.com/abetlen/llama-cpp-python/blob/ad963a0961b04195d6e360ac041b4c558495e0da/llama_cpp/_utils.py#L6-L7)

## How has this been tested?

1. Install a later version of transformers with torch:

   ```
   python -m pip install "transformers[torch]>=4.35.0"
   ```

2. Checkout main

   ```
   git checkout main
   ```

3. Verify that this command prints out the ignored Exception:

   ```
   python -c "import transformers; from llama_cpp import Llama; llm = Llama(model_path='./some.gguf', verbose=False)"
   ```

4. Checkout this branch

   ```
   git checkout ignore-warnings-on-shutdown
   ```

5. Verify that the same command **does not** print out the ignored Exception:

   ```
   python -c "import transformers; from llama_cpp import Llama; llm = Llama(model_path='./some.gguf', verbose=False)"
   ```