### PR TITLE
Multistage CUDA Dockerfile for building for building local repository for

### DIFF
--- a/cuda.Dockerfile
+++ b/cuda.Dockerfile
@@ -1,0 +1,43 @@
+ARG CUDA_VERSION="12.1.1"
+ARG OS="ubuntu22.04"
+
+ARG CUDA_BUILDER_IMAGE="${CUDA_VERSION}-devel-${OS}"
+ARG CUDA_RUNTIME_IMAGE="${CUDA_VERSION}-runtime-${OS}"
+FROM nvidia/cuda:${CUDA_BUILDER_IMAGE} as builder
+
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y git build-essential \
+    python3 python3-pip gcc wget \
+    ocl-icd-opencl-dev opencl-headers clinfo \
+    libclblast-dev libopenblas-dev \
+    && mkdir -p /etc/OpenCL/vendors && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+
+COPY . .
+
+# setting build related env vars
+ENV CUDA_DOCKER_ARCH=all
+ENV LLAMA_CUBLAS=1
+
+# Install depencencies
+RUN python3 -m pip install --upgrade pip
+# RUN python3 -m pip install --upgrade pip pytest cmake scikit-build setuptools fastapi uvicorn sse-starlette pydantic-settings starlette-context
+
+# Install llama-cpp-python (build with cuda)
+RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install -e .[server]
+RUN make clean
+
+FROM nvidia/cuda:${CUDA_RUNTIME_IMAGE} as runtime
+
+# We need to set the host to 0.0.0.0 to allow outside access
+ENV HOST 0.0.0.0
+ENV CUDA_DOCKER_ARCH=all
+
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y python3 python3-pip \
+    && apt-get clean
+
+COPY --from=builder /usr/local/lib/python3.10/dist-packages /usr/local/lib/python3.10/dist-packages
+COPY . .
+
+# Run the server
+CMD python3 -m llama_cpp.server


### PR DESCRIPTION
The existing dockerfile for cuda has a few flaws
- It builds the pypi package instead of the local repository
- Image requires too much space ~4GB

This change rectifies these such as:
- The image size is reduced to ~1.5GB (see https://hub.docker.com/r/peturparkur/llama-cpp-python)
- It builds the local repository instead of pypi
    - This allows people to make small local changes and build the image themselves

This is achieved with a multistage build, using the cuda devel image only for building the package and the runtime image for the actual deployment/runtime.