### PR TITLE
Fix logits_to_logprobs for 2-D and 3-D logits

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -2289,7 +2289,7 @@ class Llama:
             logits_maxs[~np.isfinite(logits_maxs)] = 0
         elif not np.isfinite(logits_maxs):
             logits_maxs = 0
-        subtract_maxs = logits - logits_maxs
+        subtract_maxs = np.subtract(logits, logits_maxs, dtype=np.single)
         exp = np.exp(subtract_maxs)
         # Suppress warnings about log of zero
         with np.errstate(divide='ignore'):

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -771,7 +771,7 @@ class Llama:
         **kwargs,  # type: ignore
     ):
         """Load a llama.cpp model from `model_path`.
-    
+
         Examples:
             Basic usage
 
@@ -2280,14 +2280,22 @@ class Llama:
         return self._model.token_nl()
 
     @staticmethod
-    def logits_to_logprobs(logits: npt.NDArray[np.single]) -> npt.NDArray[np.single]:
-        maximum = np.max(logits)
-        tmp = np.subtract(logits, maximum, dtype=np.single)
-        np.exp(tmp, out=tmp)
-        normalizer = 1.0 / np.sum(tmp)
-        np.multiply(normalizer, tmp, out=tmp)
-        np.log(tmp, out=tmp)
-        return tmp
+    def logits_to_logprobs(
+        logits: Union[List, npt.NDArray[np.single]], axis: int = -1
+    ) -> npt.NDArray[np.single]:
+        # https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.log_softmax.html
+        logits_maxs: np.ndarray = np.amax(logits, axis=axis, keepdims=True)
+        if logits_maxs.ndim > 0:
+            logits_maxs[~np.isfinite(logits_maxs)] = 0
+        elif not np.isfinite(logits_maxs):
+            logits_maxs = 0
+        subtract_maxs = logits - logits_maxs
+        exp = np.exp(subtract_maxs)
+        # Suppress warnings about log of zero
+        with np.errstate(divide='ignore'):
+            summed = np.sum(exp, axis=axis, keepdims=True)
+            out = np.log(summed)
+        return subtract_maxs - out
 
     @staticmethod
     def longest_token_prefix(a: Sequence[int], b: Sequence[int]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,12 @@ server = [
     "fastapi>=0.100.0",
     "pydantic-settings>=2.0.1",
     "sse-starlette>=1.6.1",
-    "starlette-context>=0.3.6,<0.4"
+    "starlette-context>=0.3.6,<0.4",
 ]
 test = [
     "pytest>=7.4.0",
     "httpx>=0.24.1",
+    "scipy>=1.10",
 ]
 dev = [
     "black>=23.3.0",

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -285,6 +285,7 @@ def test_logits_to_logprobs(size_and_axis, convert_to_list: bool, atol: float = 
     log_probs = llama_cpp.Llama.logits_to_logprobs(logits, axis=axis)
     log_probs_correct = log_softmax(logits, axis=axis)
     assert log_probs.dtype == np.single
+    assert log_probs.shape == size
     assert np.allclose(log_probs, log_probs_correct, atol=atol)
 
 

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -284,6 +284,7 @@ def test_logits_to_logprobs(size_and_axis, convert_to_list: bool, atol: float = 
         logits = logits.tolist()
     log_probs = llama_cpp.Llama.logits_to_logprobs(logits, axis=axis)
     log_probs_correct = log_softmax(logits, axis=axis)
+    assert log_probs.dtype == np.single
     assert np.allclose(log_probs, log_probs_correct, atol=atol)
 
 

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -1,6 +1,8 @@
 import ctypes
 
+import numpy as np
 import pytest
+from scipy.special import log_softmax
 
 import llama_cpp
 
@@ -262,6 +264,27 @@ def test_llama_server():
             }
         ],
     }
+
+
+@pytest.mark.parametrize(
+    "size_and_axis",
+    [
+        ((32_000,), -1),  # last token's next-token logits
+        ((10, 32_000), -1),  # many tokens' next-token logits, or batch of last tokens
+        ((4, 10, 32_000), -1),  # batch of texts
+    ],
+)
+@pytest.mark.parametrize("convert_to_list", [True, False])
+def test_logits_to_logprobs(size_and_axis, convert_to_list: bool, atol: float = 1e-7):
+    size, axis = size_and_axis
+    logits: np.ndarray = -np.random.uniform(low=0, high=60, size=size)
+    logits = logits.astype(np.single)
+    if convert_to_list:
+        # Currently, logits are converted from arrays to lists. This may change soon
+        logits = logits.tolist()
+    log_probs = llama_cpp.Llama.logits_to_logprobs(logits, axis=axis)
+    log_probs_correct = log_softmax(logits, axis=axis)
+    assert np.allclose(log_probs, log_probs_correct, atol=atol)
 
 
 def test_llama_cpp_version():


### PR DESCRIPTION
The [implementation in main](https://github.com/abetlen/llama-cpp-python/blob/8e44a32075de4aba2fc9877d4a2a34a0e7314c0d/llama_cpp/llama.py#L2282-L2290) (from [this PR](https://github.com/abetlen/llama-cpp-python/pull/991)) only works for 1-D logits. It silently fails for 2-D or 3-D logits. The implementation in this PR works out-of-the-box for 1-D, 2-D, and 3-D logits. (3-D is possible in the future w/ batch inference and `logits_all=True`.) This feature might be useful b/c there are [some](https://github.com/abetlen/llama-cpp-python/blob/8e44a32075de4aba2fc9877d4a2a34a0e7314c0d/llama_cpp/llama.py#L1785-L1787) places in the code where we can save time by vectorizing / not converting data to lists. I'll do that in a future PR.

The minimal and sufficient fix is to set `axis=-1` in the `np.max` call, and set `keepdims=True` in the `np.sum` call. I decided to instead go with a more robust implementation. It's almost copy-pasted from [`scipy.special.log_softmax`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.log_softmax.html). I decided against adding `scipy` as a required dependency b/c it's not lightweight—the latest version is ~37 MB.


## How has this been tested?

### Script

1. Install the new test dependency, `scipy`, which contains a correct implementation

   ```bash
   python -m pip install scipy
   ```

2. Checkout main

   ```bash
   git checkout main
   ```

3. Run this script in main to verify that the current implementation is silently wrong for 2-D logits

   ```python
   from __future__ import annotations
   
   import numpy as np
   from scipy.special import log_softmax
   
   from llama_cpp import Llama
   
   atol = 1e-3  # intentionally set to be loose when testing the impl in main
   size = (2, 3)
   logits: list = (
       (-np.random.uniform(low=0, high=60, size=size)).astype(np.single).tolist()
   )
   
   logprobs = Llama.logits_to_logprobs(logits)
   logprobs_correct = log_softmax(logits, axis=-1)
   assert np.allclose(logprobs, logprobs_correct, atol=atol)
   
   ```

4. Checkout this branch

   ```bash
   git checkout kddubey/fix-logits-to-logprobs
   ```

5. Run the same script with `atol=1e-6`. No error should be raised.


### New unit tests

```
pytest tests/test_llama.py -k test_logits_to_logprobs
```