### PR TITLE
Implement GGUF metadata KV overrides

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -894,7 +894,7 @@ class Llama:
 
             # null array sentinel
             self._kv_overrides_array[n_overrides].key = self._kv_overrides_array_sentinel_key
-            self.model_params.kv_overrides = ctypes.pointer(self._kv_overrides_array[0])
+            self.model_params.kv_overrides = self._kv_overrides_array
 
         self.n_batch = min(n_ctx, n_batch)  # ???
         self.n_threads = n_threads or max(multiprocessing.cpu_count() // 2, 1)
@@ -2178,7 +2178,7 @@ class Llama:
             vocab_only=self.model_params.vocab_only,
             use_mmap=self.model_params.use_mmap,
             use_mlock=self.model_params.use_mlock,
-            kv_overrides=self.model_params.kv_overrides,
+            kv_overrides=self.kv_overrides,
             # Context Params
             seed=self.context_params.seed,
             n_ctx=self.context_params.n_ctx,

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -314,11 +314,16 @@ class llama_batch(Structure):
 #     LLAMA_KV_OVERRIDE_FLOAT,
 #     LLAMA_KV_OVERRIDE_BOOL,
 # };
-class llama_model_kv_override_type(Structure):
+LLAMA_KV_OVERRIDE_INT = 0
+LLAMA_KV_OVERRIDE_FLOAT = 1
+LLAMA_KV_OVERRIDE_BOOL = 2
+
+# Union for different data types
+class ValueUnion(ctypes.Union):
     _fields_ = [
-        ("LLAMA_KV_OVERRIDE_INT", c_int),
-        ("LLAMA_KV_OVERRIDE_FLOAT", c_int),
-        ("LLAMA_KV_OVERRIDE_BOOL", c_int),
+        ("int_value", ctypes.c_int64),
+        ("float_value", c_double),
+        ("bool_value", c_bool),
     ]
 
 # struct llama_model_kv_override {
@@ -333,10 +338,8 @@ class llama_model_kv_override_type(Structure):
 class llama_model_kv_override(Structure):
     _fields_ = [
         ("key", ctypes.c_char * 128),
-        ("tag", llama_model_kv_override_type),
-        ("int_value", ctypes.c_int64),
-        ("float_value", c_double),
-        ("bool_value", c_bool),
+        ("tag", ctypes.c_int),
+        ("value", ValueUnion),
     ]
 
 # struct llama_model_params {

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -324,7 +324,6 @@ LLAMA_KV_OVERRIDE_INT = 0
 LLAMA_KV_OVERRIDE_FLOAT = 1
 LLAMA_KV_OVERRIDE_BOOL = 2
 
-
 # struct llama_model_kv_override {
 #     char key[128];
 #     enum llama_model_kv_override_type tag;

--- a/llama_cpp/server/model.py
+++ b/llama_cpp/server/model.py
@@ -79,7 +79,7 @@ class LlamaProxy:
             for kv in settings.kv_overrides:
                 key, value = kv.split("=")
                 if ":" in value:
-                    value, value_type = value.split(":")
+                    value_type, value = value.split(":")
                     if value_type == "bool":
                         kv_overrides[key] = value.lower() in ["true", "1"]
                     elif value_type == "int":

--- a/llama_cpp/server/model.py
+++ b/llama_cpp/server/model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Union, List
+from typing import Dict, Optional, Union, List
 
 import llama_cpp
 
@@ -71,6 +71,23 @@ class LlamaProxy:
             chat_handler = llama_cpp.llama_chat_format.Llava15ChatHandler(
                 clip_model_path=settings.clip_model_path, verbose=settings.verbose
             )
+        
+        kv_overrides: Optional[Dict[str, Union[bool, int, float]]] = None
+        if settings.kv_overrides is not None:
+            assert isinstance(settings.kv_overrides, list)
+            kv_overrides = {}
+            for kv in settings.kv_overrides:
+                key, value = kv.split("=")
+                if ":" in value:
+                    value, value_type = value.split(":")
+                    if value_type == "bool":
+                        kv_overrides[key] = value.lower() in ["true", "1"]
+                    elif value_type == "int":
+                        kv_overrides[key] = int(value)
+                    elif value_type == "float":
+                        kv_overrides[key] = float(value)
+                    else:
+                        raise ValueError(f"Unknown value type {value_type}")
 
         _model = llama_cpp.Llama(
             model_path=settings.model,
@@ -81,6 +98,7 @@ class LlamaProxy:
             vocab_only=settings.vocab_only,
             use_mmap=settings.use_mmap,
             use_mlock=settings.use_mlock,
+            kv_overrides=kv_overrides,
             # Context Params
             seed=settings.seed,
             n_ctx=settings.n_ctx,

--- a/llama_cpp/server/settings.py
+++ b/llama_cpp/server/settings.py
@@ -48,6 +48,10 @@ class ModelSettings(BaseSettings):
         default=llama_cpp.llama_mlock_supported(),
         description="Use mlock.",
     )
+    kv_overrides: Optional[List[str]] = Field(
+        default=None,
+        description="List of model kv overrides in the format key=value:type where type is one of (bool, int, float). Valid true values are (true, TRUE, 1), otherwise false.",
+    )
     # Context Params
     seed: int = Field(
         default=llama_cpp.LLAMA_DEFAULT_SEED, description="Random seed. -1 for random."

--- a/llama_cpp/server/settings.py
+++ b/llama_cpp/server/settings.py
@@ -50,7 +50,7 @@ class ModelSettings(BaseSettings):
     )
     kv_overrides: Optional[List[str]] = Field(
         default=None,
-        description="List of model kv overrides in the format key=value:type where type is one of (bool, int, float). Valid true values are (true, TRUE, 1), otherwise false.",
+        description="List of model kv overrides in the format key=type:value where type is one of (bool, int, float). Valid true values are (true, TRUE, 1), otherwise false.",
     )
     # Context Params
     seed: int = Field(


### PR DESCRIPTION
Quick implementation of KV overrides which accepts strings in llama.cpp `--kv_overrides KEY=TYPE:VALUE ..` format. For example `llama.expert_used_count=int:3`  Multiple overrides may be space separated.

Not that familiar with ctypes or the preferred types to use here.

Closes #1084 