### PR TITLE
Bug fixed with n_ctx=0

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -923,6 +923,12 @@ class Llama:
         self._model = _LlamaModel(
             path_model=self.model_path, params=self.model_params, verbose=self.verbose
         )
+        # Set the default value for the context and correct the batch
+        if n_ctx == 0:
+            n_ctx = self._model.n_ctx_train()
+            self.n_batch = min(n_ctx, n_batch)
+            self.context_params.n_ctx = self._model.n_ctx_train()
+            self.context_params.n_batch = self.n_batch
 
         self._ctx = _LlamaContext(
             model=self._model,


### PR DESCRIPTION
If the ```n_ctx``` parameter is set to 0 the function should use the maximum context length of the selected model, but it didn't work. There was a problem with the initialization of this parameter and a related problem with ```n_batch```.

I know that the code is not the best one, but in order to get the model information about the context I needed to add it after the creation of the model instance at line 923 of the file  ```llama.py```.
```python
self._model = _LlamaModel(
    path_model=self.model_path, params=self.model_params, verbose=self.verbose
)
``` 

Unfortunately, different objects were already initialized, therefore in the fix I had to change the ```n_ctx```, ```self.n_batch```, ```self.context_params.n_ctx``` and ```self.context_params.n_batch``` variables even if they already had a value.

Tell me if you find a smarter or more elegant solution to change the code and i will implement it. 

This change should also fix #988.

Thank you
