### PR TITLE
Don't convert logprobs arrays to lists

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1555,7 +1555,7 @@ class Llama:
                             self.detokenize(completion_tokens[:returned_tokens])
                         )
                         token_offset = len(prompt_tokens) + returned_tokens
-                        logits = self._scores[token_offset - 1, :].tolist()
+                        logits = self._scores[token_offset - 1, :]
                         current_logprobs = Llama.logits_to_logprobs(logits)
                         sorted_logprobs = list(
                             sorted(
@@ -1674,7 +1674,7 @@ class Llama:
                         self.detokenize(completion_tokens[:returned_tokens])
                     )
                     token_offset = len(prompt_tokens) + returned_tokens - 1
-                    logits = self._scores[token_offset, :].tolist()
+                    logits = self._scores[token_offset, :]
                     current_logprobs = Llama.logits_to_logprobs(logits)
                     sorted_logprobs = list(
                         sorted(
@@ -1788,9 +1788,8 @@ class Llama:
                 self.detokenize([token]).decode("utf-8", errors="ignore")
                 for token in all_tokens
             ]
-            all_logprobs = [
-                Llama.logits_to_logprobs(row.tolist()) for row in self._scores
-            ][token_offset:]
+            all_logprobs = Llama.logits_to_logprobs(self._scores)[token_offset:]
+            # TODO: may be able to change this loop to use np.take_along_dim
             for token, token_str, logprobs_token in zip(
                 all_tokens, all_token_strs, all_logprobs
             ):
@@ -2287,7 +2286,7 @@ class Llama:
 
     @staticmethod
     def logits_to_logprobs(
-        logits: Union[List, npt.NDArray[np.single]], axis: int = -1
+        logits: Union[npt.NDArray[np.single], List], axis: int = -1
     ) -> npt.NDArray[np.single]:
         # https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.log_softmax.html
         logits_maxs: np.ndarray = np.amax(logits, axis=axis, keepdims=True)
@@ -2298,7 +2297,7 @@ class Llama:
         subtract_maxs = np.subtract(logits, logits_maxs, dtype=np.single)
         exp = np.exp(subtract_maxs)
         # Suppress warnings about log of zero
-        with np.errstate(divide='ignore'):
+        with np.errstate(divide="ignore"):
             summed = np.sum(exp, axis=axis, keepdims=True)
             out = np.log(summed)
         return subtract_maxs - out


### PR DESCRIPTION
Follow-up to #1002

## Speedup

Run this in an `ipython` shell (`python -m pip install jupyter` if you don't have it already)

```python
import numpy as np
from llama_cpp import Llama

_scores: np.ndarray = -np.random.default_rng(123).uniform(
    low=0, high=60, size=(20, 32_000)
)
token_offset = 1

print("time old")
%timeit [Llama.logits_to_logprobs(row.tolist()) for row in _scores][token_offset:]
print()
print("time new")
%timeit Llama.logits_to_logprobs(_scores)[token_offset:]

```

prints

```
time old
72.6 ms ± 862 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

time new
24.5 ms ± 142 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```


## How has this been tested?

```python
import numpy as np
from llama_cpp import Llama

_scores: np.ndarray = -np.random.default_rng(123).uniform(
    low=0, high=60, size=(20, 32_000)
)
token_offset = 1

# 1-D case
logits = _scores[token_offset, :]
current_logprobs_old = Llama.logits_to_logprobs(logits.tolist())
current_logprobs_new = Llama.logits_to_logprobs(logits)
assert np.allclose(current_logprobs_old, current_logprobs_new)

# 2-D case
all_logprobs_old = [Llama.logits_to_logprobs(row.tolist()) for row in _scores][
    token_offset:
]
all_logprobs_new = Llama.logits_to_logprobs(_scores)[token_offset:]
assert np.allclose(all_logprobs_old, all_logprobs_new)

```