### PR TITLE
fix text_offset of multi-token characters

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1789,13 +1789,12 @@ class Llama:
             ]
             all_logprobs = Llama.logits_to_logprobs(self._scores)[token_offset:]
             # TODO: may be able to change this loop to use np.take_along_dim
-            for token, token_str, logprobs_token in zip(
+            for idx, (token, token_str, logprobs_token) in enumerate(zip(
                 all_tokens, all_token_strs, all_logprobs
-            ):
+            )):
                 if token == self.token_bos():
                     continue
-                text_offsets.append(text_offset)
-                text_offset += len(token_str)
+                text_offsets.append(text_offset + len(self.detokenize(all_tokens[:idx])))
                 tokens.append(token_str)
                 sorted_logprobs = list(
                     sorted(

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1551,7 +1551,9 @@ class Llama:
                             "utf-8", errors="ignore"
                         )
                         text_offset = len(prompt) + len(
-                            self.detokenize(completion_tokens[:returned_tokens])
+                            self.detokenize(completion_tokens[:returned_tokens]).decode(
+                                "utf-8", errors="ignore"
+                            )
                         )
                         token_offset = len(prompt_tokens) + returned_tokens
                         logits = self._scores[token_offset - 1, :]
@@ -1789,12 +1791,19 @@ class Llama:
             ]
             all_logprobs = Llama.logits_to_logprobs(self._scores)[token_offset:]
             # TODO: may be able to change this loop to use np.take_along_dim
-            for idx, (token, token_str, logprobs_token) in enumerate(zip(
-                all_tokens, all_token_strs, all_logprobs
-            )):
+            for idx, (token, token_str, logprobs_token) in enumerate(
+                zip(all_tokens, all_token_strs, all_logprobs)
+            ):
                 if token == self.token_bos():
                     continue
-                text_offsets.append(text_offset + len(self.detokenize(all_tokens[:idx])))
+                text_offsets.append(
+                    text_offset
+                    + len(
+                        self.detokenize(all_tokens[:idx]).decode(
+                            "utf-8", errors="ignore"
+                        )
+                    )
+                )
                 tokens.append(token_str)
                 sorted_logprobs = list(
                     sorted(


### PR DESCRIPTION
Hi, this is fix for text_offset of multi-token characters.
For example, "おはようございます" will be tokenized to
<img width="336" alt="image" src="https://github.com/abetlen/llama-cpp-python/assets/8081197/3b31267c-548b-49c1-a33a-24224a68c884">
and a character "ざ" is composed of 3 tokens.
In non-stream case, text_offset is calculated from token_str's length, which will zero if token is not valid unicode, and so "ざ" is ignored and text_offset is not aligned with text.

This PR fixes it by using the same way as stream case, which detokenizes entire completion_tokens to calculate text's length.
It also fixes stream case's bug which calculates length of bytes instead of length of characters.

before
```
"prompt": "おはよう"
"text":"ございます！\n\nI’m back from my"
"text_offset":[4,5,5,5,5,6,7,8,9,10,11,12,13,14,19,24]
"tokens":["ご","","","","い","ま","す","！","\n","\n","I","’","m"," back"," from"," my"]
```

after
```
"prompt": "おはよう"
"text":"ございます！\n\nI’m back from my"
"text_offset":[4,5,5,5,6,7,8,9,10,11,12,13,14,15,20,25]
"tokens":["ご","","","","い","ま","す","！","\n","\n","I","’","m"," back"," from"," my"]
```

Example uses TheBloke/Mistral-7B-v0.1-GGUF/mistral-7b-v0.1.Q4_K_M.gguf, logprobs=1 and temperature=0.