### PR TITLE
Fix: Correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ The gguf-converted files for this model can be found here: [functionary-7b-v1](h
           }
         }
       }],
-      tool_choices=[{
+      tool_choice=[{
         "type": "function",
         "function": {
           "name": "UserDetail"


### PR DESCRIPTION
In Llama.create_chat_completion, the `tool_choice` property does not have an s on the end.
Fixing this minor typo to keep the docs up to date with the API.