### PR TITLE
Add --version flag

### DIFF
--- a/llama_cpp/server/__main__.py
+++ b/llama_cpp/server/__main__.py
@@ -49,10 +49,20 @@ def main():
         type=str,
         help="Path to a config file to load.",
     )
+    parser.add_argument(
+        "--version",
+        action='store_true',
+        help="Display version of llama_cpp server.",
+    )
     server_settings: ServerSettings | None = None
     model_settings: list[ModelSettings] = []
     args = parser.parse_args()
     try:
+        # Display version
+        if args.version:
+            from llama_cpp import __version__
+            print(f"🦙 Llama.cpp python server version {__version__}")
+            sys.exit(0)
         # Load server settings from config_file if provided
         config_file = os.environ.get("CONFIG_FILE", args.config_file)
         if config_file:

--- a/llama_cpp/server/__main__.py
+++ b/llama_cpp/server/__main__.py
@@ -58,7 +58,7 @@ def main():
     model_settings: list[ModelSettings] = []
     args = parser.parse_args()
     try:
-        # Display version
+        # Display llama_cpp version
         if args.version:
             from llama_cpp import __version__
             print(f"🦙 Llama.cpp python server version {__version__}")


### PR DESCRIPTION
Simple addition of `--version` argument flag to command line interface to allow users to query the version of llama_cpp they are running.

```bash
# Run server - request version
python3 -m llama_cpp.server --version

# Output
🦙 Llama.cpp python server version 0.2.27
```