### PR TITLE
explicit cast messages to string for RAG purposes

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -101,7 +101,7 @@ def _format_llama2(
         if system_message and i == 0:
             ret += message + seps[i % 2]
         elif message:
-            ret += role + message + " " + seps[i % 2]
+            ret += role + str(message) + " " + seps[i % 2]
         else:
             ret += role + " "
     return ret
@@ -114,7 +114,7 @@ def _format_add_colon_single(
     ret = system_message + sep
     for role, message in messages:
         if message:
-            ret += role + ": " + message + sep
+            ret += role + ": " + str(message) + sep
         else:
             ret += role + ":"
     return ret
@@ -128,7 +128,7 @@ def _format_add_colon_two(
     ret = system_message + seps[0]
     for i, (role, message) in enumerate(messages):
         if message:
-            ret += role + ": " + message + seps[i % 2]
+            ret += role + ": " + str(message) + seps[i % 2]
         else:
             ret += role + ":"
     return ret
@@ -141,7 +141,7 @@ def _format_no_colon_single(
     ret = system_message
     for role, message in messages:
         if message:
-            ret += role + message + sep
+            ret += role + str(message) + sep
         else:
             ret += role
     return ret
@@ -154,7 +154,7 @@ def _format_add_colon_space_single(
     ret = system_message + sep
     for role, message in messages:
         if message:
-            ret += role + ": " + message + sep
+            ret += role + ": " + str(message) + sep
         else:
             ret += role + ": "  # must be end with a space
     return ret
@@ -167,7 +167,7 @@ def _format_chatml(
     ret = "" if system_message == "" else system_message + sep + "\n"
     for role, message in messages:
         if message:
-            ret += role + "\n" + message + sep + "\n"
+            ret += role + "\n" + str(message) + sep + "\n"
         else:
             ret += role + "\n"
     return ret
@@ -181,7 +181,7 @@ def _format_chatglm3(
         ret += system_message
     for role, message in messages:
         if message:
-            ret += role + "\n" + " " + message
+            ret += role + "\n" + " " + str(message)
         else:
             ret += role
     return ret


### PR DESCRIPTION
Hi,

Ive been testing the openai-like-server with [Ollama-webui](https://github.com/ollama-webui/ollama-webui) and when using the rag pipeline, the code returns a list. Not a string and so I get this error from the llamacpp-python-server

```
  File "~/miniconda3/envs/local_llm/lib/python3.11/site-packages/llama_cpp/llama_chat_format.py", line 170, in _format_chatml
    ret += role + "\n" + message + sep + "\n"
           ~~~~~~~~~~~~^~~~~~~~~
TypeError: can only concatenate str (not "list") to str
```

Simply force casting messages to string before appending the chat format fixes this issue. If this is not the right way pls let me know what I can do to solve this issue.

Thanks