### PR TITLE
fix Pydantic model parsing

### DIFF
--- a/llama_cpp/llama_grammar.py
+++ b/llama_cpp/llama_grammar.py
@@ -1433,7 +1433,6 @@ class SchemaConverter:
 
     def visit(self, schema: Dict[str, Any], name: str) -> str:
         schema_type: Optional[str] = schema.get("type") # type: ignore
-        assert isinstance(schema_type, str), f"Unrecognized schema: {schema}"
         rule_name = name or "root"
 
         if "$defs" in schema:

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -1,4 +1,5 @@
 import llama_cpp
+import json
 
 tree = """
 leaf ::= "."
@@ -6,8 +7,46 @@ node ::= leaf | "(" node node ")"
 root ::= node
 """
 
+
 def test_grammar_from_string():
     grammar = llama_cpp.LlamaGrammar.from_string(tree)
     assert grammar._n_rules == 3
     assert grammar._start_rule_index == 2
+    assert grammar.grammar is not None
+
+
+def test_composed_pydantic_grammar():
+    """
+    from pydantic import BaseModel
+
+    class A(BaseModel):
+        a: int
+
+    class B(BaseModel):
+        a: A
+        b: int
+    """
+
+    # This schema corresponds to the grammar in the comment above.
+    # We don't use the pydantic models directly to avoid the dependency.
+    schema = {
+        "$defs": {
+            "A": {
+                "properties": {"a": {"title": "A", "type": "integer"}},
+                "required": ["a"],
+                "title": "A",
+                "type": "object",
+            }
+        },
+        "properties": {
+            "a": {"$ref": "#/$defs/A"},
+            "b": {"title": "B", "type": "integer"},
+        },
+        "required": ["a", "b"],
+        "title": "B",
+        "type": "object",
+    }
+
+    grammar = llama_cpp.LlamaGrammar.from_json_schema(json.dumps(schema))
+
     assert grammar.grammar is not None


### PR DESCRIPTION

Fixes https://github.com/abetlen/llama-cpp-python/issues/1048, https://github.com/abetlen/llama-cpp-python/issues/1043

### Problem

When parsing json schemas generated from a Pydantic model, if the schema has references to other models, it contains a `$defs` key, which are referred to in the schema itself via `$ref`. This `$defs` key does not have a `type` key, as it is actually defining the types - and so the `SchemaConverter` throws an error, as it requires *all* schema keys to have a type. This assert is actually not required, as it is caught later on after iterating through the various options for schema_types here:


https://github.com/abetlen/llama-cpp-python/compare/main...DeNeutoy:fix-model-parsing?expand=1#diff-22ae5683f6e444008ca0411a78851823be188bd8e7f287327397462c5671a1a4L1502


I've deleted it and added a test. Cool project, thanks!
