### PR TITLE
fix(cli): allow passing n_ctx=0 to openAI API server CLI arguments

### DIFF
--- a/llama_cpp/server/settings.py
+++ b/llama_cpp/server/settings.py
@@ -60,7 +60,7 @@ class ModelSettings(BaseSettings):
     seed: int = Field(
         default=llama_cpp.LLAMA_DEFAULT_SEED, description="Random seed. -1 for random."
     )
-    n_ctx: int = Field(default=2048, ge=1, description="The context size.")
+    n_ctx: int = Field(default=2048, ge=0, description="The context size.")
     n_batch: int = Field(
         default=512, ge=1, description="The batch size to use per eval."
     )


### PR DESCRIPTION
## What? 
This PR updates the OpenAI API server's command line arguments to allow passing `--n_ctx 0` as a command-line argument. Currently, `--n_ctx` parameter has a minimum of `1`: in `llama_cpp/server/settings.py` you can see the following context CLI parameter configuration: `n_ctx: int = Field(default=2048, ge=1, description="The context size.")`

## Why? 
As of `llama-cpp-python@0.2.24`, per #1015 by @DanieleMorotti, passing `n_ctx=0` to the `LLama` class in `llama_cpp/llama.py` automatically sets the `n_ctx` to the model's `n_ctx_train` paramter from KV, and also updates the model's `n_batch` to `min(n_ctx, n_batch)`. This is intentional to allow `llama-cpp-python` to infer the context size from the GGUF model file's KV parameters. 

However, when this change was made, the OpenAI API server's CLI argument configuration was _not_ updated, so the minimum value for the option remained at `1` - making the patch in #1015 unavailable to users of the OpenAI API serve.r 
