### PR TITLE
Automatically set chat format from gguf

### DIFF
--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -216,13 +216,13 @@ class _LlamaModel:
         for i in range(llama_cpp.llama_model_meta_count(self.model)):
             nbytes = llama_cpp.llama_model_meta_key_by_index(self.model, i, buffer, buffer_size)
             if nbytes > buffer_size:
-                buffer_size = nbytes
+                buffer_size = nbytes + 1
                 buffer = ctypes.create_string_buffer(buffer_size)
                 nbytes = llama_cpp.llama_model_meta_key_by_index(self.model, i, buffer, buffer_size)
             key = buffer.value.decode("utf-8")
             nbytes = llama_cpp.llama_model_meta_val_str_by_index(self.model, i, buffer, buffer_size)
             if nbytes > buffer_size:
-                buffer_size = nbytes
+                buffer_size = nbytes + 1
                 buffer = ctypes.create_string_buffer(buffer_size)
                 nbytes = llama_cpp.llama_model_meta_val_str_by_index(self.model, i, buffer, buffer_size)
             value = buffer.value.decode("utf-8")

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -344,21 +344,37 @@ class Llama:
             print(f"Model metadata: {self.metadata}", file=sys.stderr)
 
         if self.chat_format is None and self.chat_handler is None and "tokenizer.chat_template" in self.metadata:
-            template = self.metadata["tokenizer.chat_template"]
-            eos_token = self.detokenize([self.token_eos()]).decode("utf-8")
-            bos_token = self.detokenize([self.token_bos()]).decode("utf-8")
+            chat_format = llama_chat_format.guess_chat_format_from_gguf_metadata(self.metadata)
 
-            if self.verbose:
-                print(f"Using chat template: {template}", file=sys.stderr)
-                print(f"Using chat eos_token: {eos_token}", file=sys.stderr)
-                print(f"Using chat bos_token: {bos_token}", file=sys.stderr)
+            if chat_format is not None:
+                self.chat_format = chat_format
+                if self.verbose:
+                    print(f"Guessed chat format: {chat_format}", file=sys.stderr)
+            else:
+                template = self.metadata["tokenizer.chat_template"]
+                try:
+                    eos_token_id = int(self.metadata["tokenizer.ggml.eos_token_id"])
+                except:
+                    eos_token_id = self.token_eos()
+                try:
+                    bos_token_id = int(self.metadata["tokenizer.ggml.bos_token_id"])
+                except:
+                    bos_token_id = self.token_bos()
 
-            self.chat_handler = llama_chat_format.Jinja2ChatFormatter(
-                template=template,
-                eos_token=eos_token,
-                bos_token=bos_token
-            ).to_chat_handler()
-        
+                eos_token = self.detokenize([eos_token_id]).decode("utf-8")
+                bos_token = self.detokenize([bos_token_id]).decode("utf-8")
+
+                if self.verbose:
+                    print(f"Using chat template: {template}", file=sys.stderr)
+                    print(f"Using chat eos_token: {eos_token}", file=sys.stderr)
+                    print(f"Using chat bos_token: {bos_token}", file=sys.stderr)
+
+                self.chat_handler = llama_chat_format.Jinja2ChatFormatter(
+                    template=template,
+                    eos_token=eos_token,
+                    bos_token=bos_token
+                ).to_chat_handler()
+
         if self.chat_format is None and self.chat_handler is None:
             self.chat_format = "llama-2"
 

--- a/llama_cpp/server/settings.py
+++ b/llama_cpp/server/settings.py
@@ -113,8 +113,8 @@ class ModelSettings(BaseSettings):
         description="Enable NUMA support.",
     )
     # Chat Format Params
-    chat_format: str = Field(
-        default="llama-2",
+    chat_format: Optional[str] = Field(
+        default=None,
         description="Chat format to use.",
     )
     clip_model_path: Optional[str] = Field(


### PR DESCRIPTION
Closes #1096 

Okay so for now this is going to be the behaviour / priority of the automatic chat format detection

1. Use provided `chat_handler` param
2. Use provided `chat_format` param
3. If model has a gguf `chat_template` try to string match it against known jinja2 templates and use the matching template's eos token
4. If model has a gguf `chat_template` use `eos_token` for stop generation
5. Use llama 2 chat format