### PR TITLE
Add json schema mode

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -1441,10 +1441,14 @@ class Llava15ChatHandler:
         prompt = llama.input_ids[: llama.n_tokens].tolist()
 
         if response_format is not None and response_format["type"] == "json_object":
-            with suppress_stdout_stderr(disable=self.verbose):
-                grammar = llama_grammar.LlamaGrammar.from_string(
-                    llama_grammar.JSON_GBNF
-                )
+            try:
+                # create grammar from json schema
+                if "schema" in response_format:
+                    grammar = llama_grammar.LlamaGrammar.from_json_schema(
+                        json.dumps(response_format["schema"])
+                    )
+            except Exception as e:
+                grammar = llama_grammar.LlamaGrammar.from_string(llama_grammar.JSON_GBNF)
 
         return _convert_completion_to_chat(
             llama.create_completion(

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -318,7 +318,14 @@ def chat_formatter_to_chat_completion_handler(
             stop = stop + rstop
 
         if response_format is not None and response_format["type"] == "json_object":
-            grammar = llama_grammar.LlamaGrammar.from_string(llama_grammar.JSON_GBNF)
+            try:
+                # create grammar from json schema
+                if "schema" in response_format:
+                    grammar = llama_grammar.LlamaGrammar.from_json_schema(
+                        json.dumps(response_format["schema"])
+                    )
+            except Exception as e:
+                grammar = llama_grammar.LlamaGrammar.from_string(llama_grammar.JSON_GBNF)
 
         completion_or_chunks = llama.create_completion(
             prompt=prompt,

--- a/llama_cpp/llama_types.py
+++ b/llama_cpp/llama_types.py
@@ -154,6 +154,7 @@ class ChatCompletionFunctionCallOption(TypedDict):
 
 class ChatCompletionRequestResponseFormat(TypedDict):
     type: Literal["text", "json_object"]
+    schema: NotRequired[JsonType] # https://docs.endpoints.anyscale.com/guides/json_mode/
 
 
 class ChatCompletionRequestMessageContentPartText(TypedDict):


### PR DESCRIPTION
Adds Anyscale-style json schema mode for all simple chat formats (ie chatml, llama2, alpaca, vicuna, etc) as well as llava multimodal models. Source https://docs.endpoints.anyscale.com/guides/json_mode/

# Server Usage

This is using the python openai API but any REST client will work.

```python
import openai

client = openai.OpenAI(
    base_url="http://localhost:8000/v1", api_key="esecret_YOUR_API_KEY"
)

# Note: not all arguments are currently supported and will be ignored by the backend.
chat_completion = client.chat.completions.create(
    model="mistralai/Mixtral-8x7B-Instruct-v0.1",
    messages=[
        {
            "role": "system",
            "content": "You are a helpful assistant that outputs in JSON.",
        },
        {"role": "user", "content": "Who won the world series in 2020"},
    ],
    response_format={
        "type": "json_object",
        "schema": {
            "type": "object",
            "properties": {"team_name": {"type": "string"}},
            "required": ["team_name"],
        },
    },
    temperature=0.7,
)
print(chat_completion.model_dump())
```
```python
{'id': 'chatcmpl-60994326-99f9-41f6-8fc0-ae9b08026521', 'choices': [{'finish_reason': 'stop', 'index': 0, 'logprobs': None, 'message': {'content': '{ "team_name": "Los Angeles Dodgers" } ', 'role': 'assistant', 'function_call': None, 'tool_calls': None}}], 'created': 1706391561, 'model': 'mistralai/Mixtral-8x7B-Instruct-v0.1', 'object': 'chat.completion', 'system_fingerprint': None, 'usage': {'completion_tokens': 16, 'prompt_tokens': 65, 'total_tokens': 81}}
```

# Python Usage

```python
>>> from llama_cpp import Llama
>>> llm = Llama(model_path="path/to/model.gguf", chat_format="chatml")
>>> llm.create_chat_completion(
    messages=[
        {
            "role": "system",
            "content": "You are a helpful assistant that outputs in JSON.",
        },
        {"role": "user", "content": "Who won the world series in 2020"},
    ],
    response_format={
        "type": "json_object",
        "schema": {
            "type": "object",
            "properties": {"team_name": {"type": "string"}},
            "required": ["team_name"],
        },
    },
    temperature=0.7,
)
```
```python
{'id': 'chatcmpl-60994326-99f9-41f6-8fc0-ae9b08026521', 'choices': [{'finish_reason': 'stop', 'index': 0, 'logprobs': None, 'message': {'content': '{ "team_name": "Los Angeles Dodgers" } ', 'role': 'assistant', 'function_call': None, 'tool_calls': None}}], 'created': 1706391561, 'model': 'mistralai/Mixtral-8x7B-Instruct-v0.1', 'object': 'chat.completion', 'system_fingerprint': None, 'usage': {'completion_tokens': 16, 'prompt_tokens': 65, 'total_tokens': 81}}
```