### PR TITLE
Added functionary v2.2 chat handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,12 +221,12 @@ Chat completion is available through the [`create_chat_completion`](https://llam
 The high-level API also provides a simple interface for function calling.
 
 Note that the only model that supports full function calling at this time is "functionary".
-The gguf-converted files for this model can be found here: [functionary-7b-v1](https://huggingface.co/abetlen/functionary-7b-v1-GGUF)
+The gguf-converted files for this model can be found here: [functionary-v2.2](https://huggingface.co/meetkai/functionary-medium-v2.2-GGUF)
 
 
 ```python
 >>> from llama_cpp import Llama
->>> llm = Llama(model_path="path/to/functionary/llama-model.gguf", chat_format="functionary")
+>>> llm = Llama(model_path="path/to/functionary/llama-model.gguf", chat_format="functionary2")
 >>> llm.create_chat_completion(
       messages = [
         {
@@ -260,12 +260,7 @@ The gguf-converted files for this model can be found here: [functionary-7b-v1](h
           }
         }
       }],
-      tool_choice=[{
-        "type": "function",
-        "function": {
-          "name": "UserDetail"
-        }
-      }]
+      tool_choice="auto"
 )
 ```
 


### PR DESCRIPTION
- Supports streaming and no streaming
- Tested on local project
- I used the same code that generated schema for tool calls in `functionary` chat handler, rewrote almost everything else as they completely changed the format.
- Built-in tokenizer had problems tokenizing special tokens like `<|content|>` and `<|stop|>` so I had to use `transformers` package to get an `AutoTokenizer` that works with this model and just plug it with `llama.generate`.
  - As a side effect of this, `sentencepiece` is now a requirement.
- Updated readme to reflect support for the newest model the I tested as of now.
- Chat format is set as `functionary2` to retain compatibility with any code that uses the old formatter with older models.

Here are samples of the [new chat format](https://github.com/MeetKai/functionary/blob/main/tests/prompt_test_v2.txt) and [old chat format](https://github.com/MeetKai/functionary/blob/main/tests/prompt_test_v1.txt).

Please note that current `functionary` handler **didn't work** with functionary model v1.4.