### PR TITLE
Add custom routers register to `create_app`

### DIFF
--- a/examples/high_level_api/fastapi_server.py
+++ b/examples/high_level_api/fastapi_server.py
@@ -3,34 +3,59 @@
 To run this example:
 
 ```bash
-pip install fastapi uvicorn sse-starlette
-export MODEL=../models/7B/...
+python examples/high_level_api/fastapi_server.py --model <path/to/your/model>
 ```
-
-Then run:
-```
-uvicorn --factory llama_cpp.server.app:create_app --reload
-```
-
-or
-
-```
-python3 -m llama_cpp.server
-```
-
-Then visit http://localhost:8000/docs to see the interactive API docs.
-
 
 To actually see the implementation of the server, see llama_cpp/server/app.py
 
 """
 import os
 import uvicorn
+import argparse
 
 from llama_cpp.server.app import create_app
+from llama_cpp.server.cli import parse_model_from_args
+from llama_cpp.server.settings import (
+    ServerSettings,
+    ModelSettings,
+)
+
+from fastapi import APIRouter
+
+# you can even customize your own router above the llama_cpp server
+
+test_router = APIRouter()
+
+@test_router.get("/llm")
+def test_llm():
+    return {'status': 'OK'}
 
 if __name__ == "__main__":
-    app = create_app()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model",
+        type=str,
+        help="Path to your model",
+    )
+    args = parser.parse_args()
+    server_settings = parse_model_from_args(ServerSettings, args)
+    model_settings = [parse_model_from_args(ModelSettings, args)]
+    
+    """
+        By default, we can use:
+            app = create_app()
+        to create a FastAPI app for serving.
+        
+        If you add your custom routers, you can simply use:
+            app = create_app(custom_routers=<your_router_here>)
+        to register your custom routers above llama_cpp.server's routers.
+    """
+    
+    app = create_app(
+        server_settings=server_settings,
+        model_settings=model_settings,
+        custom_routers=test_router
+    )
 
     uvicorn.run(
         app, host=os.getenv("HOST", "localhost"), port=int(os.getenv("PORT", 8000))

--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -5,7 +5,7 @@ import json
 
 from threading import Lock
 from functools import partial
-from typing import Iterator, List, Optional, Union, Dict
+from typing import Iterator, List, Optional, Union, Dict, Iterable
 
 import llama_cpp
 
@@ -93,6 +93,7 @@ def create_app(
     settings: Settings | None = None,
     server_settings: ServerSettings | None = None,
     model_settings: List[ModelSettings] | None = None,
+    custom_routers: Union[APIRouter, Iterable[APIRouter], None] = None,
 ):
     config_file = os.environ.get("CONFIG_FILE", None)
     if config_file is not None:
@@ -128,6 +129,12 @@ def create_app(
         allow_headers=["*"],
     )
     app.include_router(router)
+    
+    if custom_routers is not None:
+        if isinstance(custom_routers, APIRouter):
+            custom_routers = (custom_routers,)
+        for _router in custom_routers:
+            app.include_router(_router)
 
     assert model_settings is not None
     set_llama_proxy(model_settings=model_settings)


### PR DESCRIPTION
## Overview
This PR introduces the `custom_routers` parameter to the `create_app` function. 

In cases when developers need to build their own business logic above llama-cpp-server, thus we may need to register a router to `app` to enhance the flexibility and modularity of the application setup.

---

Besides, I tried to write example script for this new parameter, and I noticed that `fastapi_server.py` cannot be launched successfully due to the lack of settings. 

(*And I think we should provide a clear example script for developers to know how to launch a llama-cpp FastAPI server on their own instead of the command line way.*)

So several changes are done to `fastapi_server.py`, referencing `__main__.py` and minimizing the preparation steps for launching.

## Changes
+ add a new parameter `custom_routers` in `create_app()`.
+ modify `examples/high_level_api/fastapi_server.py` to enable it's capability.