### PR TITLE
Use proper backend for CLIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,14 @@ if (LLAMA_BUILD)
     )
 
     if (LLAVA_BUILD)
+        if (LLAMA_CUBLAS)
+            add_compile_definitions(GGML_USE_CUBLAS)
+        endif()
+
+        if (LLAMA_METAL)
+            add_compile_definitions(GGML_USE_METAL)
+        endif()
+
         # Building llava
         add_subdirectory(vendor/llama.cpp/examples/llava)
         set_target_properties(llava_shared PROPERTIES OUTPUT_NAME "llava")


### PR DESCRIPTION
When using LLaVa, CLIP does not load on the default backend (i.e. CUDA/Metal when they are available). This arises because the code in `clip.cpp` conditions on `GGML_USE_XXX` rather than `LLAMA_USE_XXX`. The main `llama.cpp` CMake file enables the former when the latter is present, but we need to do it manually for LLaVA since we're bypassing the top level.