### PR TITLE
Batch embed strings to fit model context

### DIFF
--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -506,6 +506,14 @@ class _LlamaBatch:
             self._llama_batch_free(self.batch)
             self.batch = None
 
+    def n_tokens(self) -> int:
+        assert self.batch is not None
+        return self.batch.n_tokens
+
+    def reset(self):
+        assert self.batch is not None
+        self.batch.n_tokens = 0
+
     def set_batch(self, batch: Sequence[int], n_past: int, logits_all: bool):
         assert self.batch is not None
         n_tokens = len(batch)
@@ -516,6 +524,20 @@ class _LlamaBatch:
             self.batch.seq_id[i][0] = 0
             self.batch.n_seq_id[i] = 1
             self.batch.logits[i] = logits_all
+        self.batch.logits[n_tokens - 1] = True
+
+    def add_sequence(self, batch: Sequence[int], seq_id: int, logits_all: bool):
+        assert self.batch is not None
+        n_tokens = len(batch)
+        n_tokens0 = self.batch.n_tokens
+        self.batch.n_tokens += n_tokens
+        for i in range(n_tokens):
+            j = n_tokens0 + i
+            self.batch.token[j] = batch[i]
+            self.batch.pos[j] = i
+            self.batch.seq_id[j][0] = seq_id
+            self.batch.n_seq_id[j] = 1
+            self.batch.logits[j] = logits_all
         self.batch.logits[n_tokens - 1] = True
 
 

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -836,6 +836,9 @@ class Llama:
 
         output = data[0] if isinstance(input, str) else data
 
+        llama_cpp.llama_kv_cache_clear(self._ctx.ctx)
+        self.reset()
+
         if return_count:
             return output, total_tokens
         else:


### PR DESCRIPTION
Now that `llama.cpp` supports BERT embedding models (https://github.com/ggerganov/llama.cpp/pull/5423), this modifies `embed` / `create_embedding` to truncate and combine inputs to fit into the model context size and allows for efficient high-volume embedding. I tried to be minimal with changes, and am definitely open to alternate suggestions. What we have now:

* Add `reset` and `add_sequence` methods to `_LlamaBatch` to make multi-sequence batches
* Tokens are truncated to `n_ctx` by default, and without truncation an error is thrown if `n_tokens > n_ctx`
* Embeddings are normalized by default but this can be turned off

One could eke out some gains from grouping batches more intelligently, but I wanted to keep it simple.