### PR TITLE
Update README.md to fix pip install llama cpp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,14 +416,14 @@ This allows you to use llama.cpp compatible models with any OpenAI compatible cl
 To install the server package and get started:
 
 ```bash
-pip install llama-cpp-python[server]
+pip install 'llama-cpp-python[server]'
 python3 -m llama_cpp.server --model models/7B/llama-model.gguf
 ```
 
 Similar to Hardware Acceleration section above, you can also install with GPU (cuBLAS) support like this:
 
 ```bash
-CMAKE_ARGS="-DLLAMA_CUBLAS=on" FORCE_CMAKE=1 pip install llama-cpp-python[server]
+CMAKE_ARGS="-DLLAMA_CUBLAS=on" FORCE_CMAKE=1 pip install 'llama-cpp-python[server]'
 python3 -m llama_cpp.server --model models/7B/llama-model.gguf --n_gpu_layers 35
 ```
 


### PR DESCRIPTION
Without the single quotes, when running the command, an error is printed saying no matching packages found on pypi. Adding the quotes fixes it

```bash
$ pip install llama-cpp-python[server]
zsh: no matches found: llama-cpp-python[server]
```

Fix found the llama.cpp repo in [comments](https://github.com/ggerganov/llama.cpp/discussions/795#discussioncomment-6226069) is to use this command `pip install 'llama-cpp-python[server]'`