### PR TITLE
switch to '\n' for EventSourceResponse separator

### DIFF
--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -290,6 +290,7 @@ async def create_completion(
                 inner_send_chan=send_chan,
                 iterator=iterator(),
             ),
+            sep='\n',
         )
     else:
         return iterator_or_completion
@@ -382,6 +383,7 @@ async def create_chat_completion(
                 inner_send_chan=send_chan,
                 iterator=iterator(),
             ),
+            sep='\n',
         )
     else:
         return iterator_or_completion


### PR DESCRIPTION
this fixes compatibility with some OpenAI clients, including BetterChatGPT (https://github.com/ztjhz/BetterChatGPT/issues/537). i'm not sure if this will cause problems with other clients. i'm also working with the client to see if they are willing to handle these separators more gracefully.