### PR TITLE
feat: Pull models directly from huggingface

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,19 @@ Below is a short example demonstrating how to use the high-level API to for basi
 
 Text completion is available through the [`__call__`](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#llama_cpp.Llama.__call__) and [`create_completion`](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#llama_cpp.Llama.create_completion) methods of the [`Llama`](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#llama_cpp.Llama) class.
 
+## Pulling models from Hugging Face
+
+You can pull `Llama` models from Hugging Face using the `from_pretrained` method.
+You'll need to install the `huggingface-hub` package to use this feature (`pip install huggingface-hub`).
+
+```python
+llama = Llama.from_pretrained(
+    repo_id="Qwen/Qwen1.5-0.5B-Chat-GGUF",
+    pattern="*q8_0.gguf",
+    verbose=False
+)
+```
+
 ### Chat Completion
 
 The high-level API also provides a simple interface for chat completion.

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ You'll need to install the `huggingface-hub` package to use this feature (`pip i
 ```python
 llama = Llama.from_pretrained(
     repo_id="Qwen/Qwen1.5-0.5B-Chat-GGUF",
-    pattern="*q8_0.gguf",
+    filename="*q8_0.gguf",
     verbose=False
 )
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -26,6 +26,7 @@ High-level Python bindings for llama.cpp.
             - load_state
             - token_bos
             - token_eos
+            - from_pretrained
         show_root_heading: true
 
 ::: llama_cpp.LlamaGrammar


### PR DESCRIPTION
Adds the ability to pull models directly from huggingface hub via a `from_pretrained` method on the `Llama` class. You'll need to `pip install huggingface-hub` to use this feature.

# Usage

```python
import llama_cpp

llama = llama_cpp.Llama.from_pretrained(
    repo_id="Qwen/Qwen1.5-0.5B-Chat-GGUF",
    filename="*q8_0.gguf",
    verbose=False
)

response = llama.create_chat_completion(
    messages=[
        {
            "role": "user",
            "content": "What is the capital of France?"
        }
    ],
    response_format={
        "type": "json_object",
        "schema": {
            "type": "object",
            "properties": {
                "country": {"type": "string"},
                "capital": {"type": "string"}
            },
            "required": ["country", "capital"],
        }
    },
    stream=True
)

for chunk in response:
    delta = chunk["choices"][0]["delta"]
    if "content" not in delta:
        continue
    print(delta["content"], end="", flush=True)

print()
```

Closes #1145 