### PR TITLE
WIP: Parallel generation implemenation

### DIFF
--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -530,6 +530,17 @@ class _LlamaBatch:
             self.batch.logits[i] = logits_all
         self.batch.logits[n_tokens - 1] = True
 
+    def set_batch_parallel(self, batch: Sequence[int], position: int, logits_all: bool):
+        assert self.batch is not None
+        n_tokens = len(batch)
+        self.batch.n_tokens = n_tokens
+        for i in range(n_tokens):
+            self.batch.token[i] = batch[i]
+            self.batch.pos[i] = position
+            self.batch.seq_id[i][0] = i
+            self.batch.n_seq_id[i] = 1
+            self.batch.logits[i] = logits_all
+
     def add_sequence(self, batch: Sequence[int], seq_id: int, logits_all: bool):
         assert self.batch is not None
         n_tokens = len(batch)


### PR DESCRIPTION
This is a basic and relatively simple implementation of parallel generation, both streaming and non-streaming, as considered in #771. It sticks mostly to using the existing high level API functions, except when messing around with the KV cache. The only real optimization is detecting a common prefix among the sequences and decoding that in a single pass, which would cover things like system prompts.

Rather than trying to fit into the existing functions, this creates new functions `eval_parallel`, `generate_parallel`, etc. Right now it just outputs lists of string results, rather than the full JSON formatting. I wanted to see if this is viable before going down that road.

The existing top-level state variables such as `n_tokens`, `scores`, and `input_ids` are geared toward single stream generation. The way I'm decoding here is position aligned, so `n_tokens` is basically the same. While `scores` now stores the logits for a single batch across multiple sequences, but in a way that `sample` still works the same. And `input_ids` and `draft_model` are ignored for now.