### PR TITLE
Add Google's Gemma formatting via `chat_format="gemma"`

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -993,6 +993,26 @@ def format_saiga(
     return ChatFormatterResponse(prompt=_prompt.strip())
 
 
+# Chat format for Google's Gemma models, see more details and available models:
+# https://huggingface.co/collections/google/gemma-release-65d5efbccdbb8c4202ec078b
+@register_chat_format("gemma")
+def format_gemma(
+    messages: List[llama_types.ChatCompletionRequestMessage],
+    **kwargs: Any,
+) -> ChatFormatterResponse:
+    system_message = _get_system_message(messages)
+    if system_message is not None and system_message != "":
+        raise ValueError(
+            "`role='system'` messages are not allowed on Google's Gemma models."
+        )
+    _roles = dict(user="<start_of_turn>user\n", assistant="<start_of_turn>model\n")
+    _sep = "<end_of_turn>\n"
+    _messages = _map_roles(messages, _roles)
+    _messages.append((_roles["assistant"], None))
+    _prompt = _format_no_colon_single(system_message="", messages=_messages, sep=_sep)
+    return ChatFormatterResponse(prompt=_prompt, stop=_sep)
+
+
 # Tricky chat formats that require custom chat handlers
 
 

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -14,6 +14,7 @@ import llama_cpp.llama as llama
 import llama_cpp.llama_types as llama_types
 import llama_cpp.llama_grammar as llama_grammar
 
+from ._logger import logger
 from ._utils import suppress_stdout_stderr, Singleton
 
 ### Common Chat Templates and Special Tokens ###
@@ -1002,7 +1003,7 @@ def format_gemma(
 ) -> ChatFormatterResponse:
     system_message = _get_system_message(messages)
     if system_message is not None and system_message != "":
-        raise ValueError(
+        logger.debug(
             "`role='system'` messages are not allowed on Google's Gemma models."
         )
     _roles = dict(user="<start_of_turn>user\n", assistant="<start_of_turn>model\n")


### PR DESCRIPTION
## Description

This PR adds the recently released Google's Gemma formatting, so that it can be used via the `chat_format` arg within the `Llama` class i.e. `chat_format="gemma"`.

More information about the models in the following HuggingFace Collection at https://huggingface.co/collections/google/gemma-release-65d5efbccdbb8c4202ec078b

_Note that some of the current GGUF versions uploaded to the HuggingFace Hub are not working fine with `llama.cpp`, but I got it working when using e.g. https://huggingface.co/rahuldshetty/gemma-7b-it-gguf-quantized/blob/main/gemma-7b-it-Q4_K_M.gguf._

## Example

```python
from llama_cpp import Llama

llm = Llama(
    model_path="./models/gemma-7b-it-Q4_K_M.gguf",
    chat_format="gemma",
    n_gpu_layers=-1,
)
print(
    llm.create_chat_completion(
        messages=[
            {"role": "user", "content": "What's the capital of Spain"},
            {"role": "assistant", "content": "Barcelona"},
            {"role": "user", "content": "No, it's not, try again."},
        ],
        max_tokens=4,
    )
)
# {'id': 'chatcmpl-6037698e-2f05-496d-b49f-f7d61dde32f3', 'object': 'chat.completion', 'created': 1708599453, 'model': './models/gemma-7b-it-Q4_K_M.gguf', 'choices': [{'index': 0, 'message': {'role': 'assistant', 'content': 'The answer is Madrid'}, 'finish_reason': 'length'}], 'usage': {'prompt_tokens': 37, 'completion_tokens': 4, 'total_tokens': 41}}
```