### PR TITLE
Switch embed to llama_get_embeddings_seq

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -814,7 +814,7 @@ class Llama:
 
             # store embeddings
             for i in range(n_seq):
-                embedding: List[float] = llama_cpp.llama_get_embeddings_ith(
+                embedding: List[float] = llama_cpp.llama_get_embeddings_seq(
                     self._ctx.ctx, i
                 )[:n_embd]
                 if normalize:

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -1803,22 +1803,6 @@ def llama_get_embeddings_ith(
     ...
 
 
-# // Get the embeddings for sequence seq_id
-# // shape: [n_embd] (1-dimensional)
-# LLAMA_API float * llama_get_embeddings_seq(struct llama_context * ctx, llama_seq_id seq_id);
-@ctypes_function(
-    "llama_get_embeddings_seq",
-    [llama_context_p_ctypes, ctypes.c_int32],
-    ctypes.POINTER(ctypes.c_float),
-)
-def llama_get_embeddings_seq(
-    ctx: llama_context_p, i: Union[ctypes.c_int32, int], /
-) -> CtypesArray[ctypes.c_float]:
-    """Get the embeddings for sequence seq_id
-    shape: [n_embd] (1-dimensional)"""
-    ...
-
-
 # // Get the embeddings for a sequence id
 # // Returns NULL if pooling_type is LLAMA_POOLING_TYPE_NONE
 # // shape: [n_embd] (1-dimensional)

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -1803,6 +1803,22 @@ def llama_get_embeddings_ith(
     ...
 
 
+# // Get the embeddings for sequence seq_id
+# // shape: [n_embd] (1-dimensional)
+# LLAMA_API float * llama_get_embeddings_seq(struct llama_context * ctx, llama_seq_id seq_id);
+@ctypes_function(
+    "llama_get_embeddings_seq",
+    [llama_context_p_ctypes, ctypes.c_int32],
+    ctypes.POINTER(ctypes.c_float),
+)
+def llama_get_embeddings_seq(
+    ctx: llama_context_p, i: Union[ctypes.c_int32, int], /
+) -> CtypesArray[ctypes.c_float]:
+    """Get the embeddings for sequence seq_id
+    shape: [n_embd] (1-dimensional)"""
+    ...
+
+
 # // Get the embeddings for a sequence id
 # // Returns NULL if pooling_type is LLAMA_POOLING_TYPE_NONE
 # // shape: [n_embd] (1-dimensional)


### PR DESCRIPTION
Due to updates in https://github.com/ggerganov/llama.cpp/pull/5796, sequence level embeddings are now output through a separate channel from token level embeddings, and they are accessed with `llama_get_embeddings_seq`.