### PR TITLE
Check for existence of clip model path

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -1848,6 +1848,9 @@ class Llava15ChatHandler:
         self.verbose = verbose
         self._clip_free = self._llava_cpp._libllava.clip_free  # type: ignore
 
+        if not os.path.exists(clip_model_path):
+            raise ValueError(f"Clip model path does not exist: {clip_model_path}")
+
         with suppress_stdout_stderr(disable=self.verbose):
             self.clip_ctx = self._llava_cpp.clip_model_load(
                 self.clip_model_path.encode(), 0


### PR DESCRIPTION
The following code,

```py
from llama_cpp.llama_chat_format import Llava15ChatHandler
Llava15ChatHandler(clip_model_path='this-path-does-not-exist')
```

When ran aborts and yields a core dump.

```
$ python3 main.py
Aborted (core dumped)
```

This PR installs a more graceful exception with an informative error message.