### PR TITLE
fix last tokens passing to sample_repetition_penalties function

### DIFF
--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -730,12 +730,14 @@ class _LlamaSamplingContext:
         if len(self.prev) > 0:
             nl_token = ctx_main.model.token_nl()
             nl_logit = logits_array[nl_token]
-            if self.params.penalty_last_n > 0:
+            last_tokens = self.prev[-self.params.penalty_last_n:]
+            last_tokens_size = min(len(last_tokens), self.params.penalty_last_n)
+            if last_tokens_size > 0:
+                last_tokens_p = (llama_cpp.llama_token * len(last_tokens))(*last_tokens)
                 ctx_main.sample_repetition_penalties(
                     token_data_array,
-                    # TODO: Only create this once
-                    (llama_cpp.llama_token * len(self.prev))(*self.prev),
-                    self.params.penalty_last_n,
+                    last_tokens_p,
+                    last_tokens_size,
                     self.params.penalty_repeat,
                     self.params.penalty_freq,
                     self.params.penalty_present,


### PR DESCRIPTION
**Bug:** currently all previous tokens are passing to `llama_sample_repetition_penalties` function instead of last `penalty_last_n` tokens.

**Description:** `llama_sample_repetition_penalties` function expects last `penalty_last_n` tokens. But it gets all previously generated tokens which leads to the algorithm not working correctly.

As you can see in the code below it will use only first `penalty_last_n` tokens to create `token_count` dict:
```
    ...
    // Create a frequency map to count occurrences of each token in last_tokens
    std::unordered_map<llama_token, int> token_count;
    for (size_t i = 0; i < penalty_last_n; ++i) {
        token_count[last_tokens[i]]++;
    }
    ...
```
This behavior is obviously incorrect which in our case led to the case where our model had a lot of answers with repetitions.

Also in this PR was fixed bug with possible buffer overflow that could cause to segfault in code above.