### PR TITLE
Add logprobs return in ChatCompletionResponse

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1641,6 +1641,9 @@ class Llama:
         handler = self.chat_handler or llama_chat_format.get_chat_completion_handler(
             self.chat_format
         )
+        _logprobs = top_logprobs
+        if not logprobs:
+            _logprobs = 0
         return handler(
             llama=self,
             messages=messages,
@@ -1653,6 +1656,7 @@ class Llama:
             top_k=top_k,
             min_p=min_p,
             typical_p=typical_p,
+            logprobs=_logprobs,
             stream=stream,
             stop=stop,
             seed=seed,

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1641,9 +1641,6 @@ class Llama:
         handler = self.chat_handler or llama_chat_format.get_chat_completion_handler(
             self.chat_format
         )
-        _logprobs = top_logprobs
-        if not logprobs:
-            _logprobs = 0
         return handler(
             llama=self,
             messages=messages,
@@ -1656,7 +1653,7 @@ class Llama:
             top_k=top_k,
             min_p=min_p,
             typical_p=typical_p,
-            logprobs=_logprobs,
+            logprobs=top_logprobs if logprobs else None,
             stream=stream,
             stop=stop,
             seed=seed,

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -231,6 +231,7 @@ def _convert_text_completion_to_chat(
                     "role": "assistant",
                     "content": completion["choices"][0]["text"],
                 },
+                "logprobs": completion["choices"][0]["logprobs"],
                 "finish_reason": completion["choices"][0]["finish_reason"],
             }
         ],
@@ -254,6 +255,7 @@ def _convert_text_completion_chunks_to_chat(
                         "delta": {
                             "role": "assistant",
                         },
+                        "logprobs": None,
                         "finish_reason": None,
                     }
                 ],
@@ -273,6 +275,7 @@ def _convert_text_completion_chunks_to_chat(
                         if chunk["choices"][0]["finish_reason"] is None
                         else {}
                     ),
+                    "logprobs": chunk["choices"][0]["logprobs"],
                     "finish_reason": chunk["choices"][0]["finish_reason"],
                 }
             ],
@@ -487,6 +490,7 @@ def chat_formatter_to_chat_completion_handler(
         temperature: float = 0.2,
         top_p: float = 0.95,
         top_k: int = 40,
+        logprobs: int = 0,
         min_p: float = 0.05,
         typical_p: float = 1.0,
         stream: bool = False,
@@ -576,6 +580,7 @@ def chat_formatter_to_chat_completion_handler(
             top_k=top_k,
             min_p=min_p,
             typical_p=typical_p,
+            logprobs=logprobs,
             stream=stream,
             stop=stop,
             seed=seed,

--- a/llama_cpp/llama_types.py
+++ b/llama_cpp/llama_types.py
@@ -84,6 +84,7 @@ class ChatCompletionFunction(TypedDict):
 class ChatCompletionResponseChoice(TypedDict):
     index: int
     message: "ChatCompletionResponseMessage"
+    logprobs: Optional[CompletionLogprobs]
     finish_reason: Optional[str]
 
 

--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -405,6 +405,18 @@ async def create_chat_completion(
                     }
                 },
             },
+            "logprobs": {
+                "summary": "Logprobs",
+                "value": {
+                    "model": "gpt-3.5-turbo",
+                    "messages": [
+                        {"role": "system", "content": "You are a helpful assistant."},
+                        {"role": "user", "content": "What is the capital of France?"},
+                    ],
+                    "logprobs": True,
+                    "top_logprobs": 10
+                },
+            },
         }
     ),
     llama_proxy: LlamaProxy = Depends(get_llama_proxy),

--- a/llama_cpp/server/types.py
+++ b/llama_cpp/server/types.py
@@ -130,7 +130,6 @@ class CreateCompletionRequest(BaseModel):
     presence_penalty: Optional[float] = presence_penalty_field
     frequency_penalty: Optional[float] = frequency_penalty_field
     logit_bias: Optional[Dict[str, float]] = Field(None)
-    logprobs: Optional[int] = Field(None)
     seed: Optional[int] = Field(None)
 
     # ignored or currently unsupported

--- a/llama_cpp/server/types.py
+++ b/llama_cpp/server/types.py
@@ -209,6 +209,15 @@ class CreateChatCompletionRequest(BaseModel):
         default=None,
         description="The maximum number of tokens to generate. Defaults to inf",
     )
+    logprobs: Optional[bool] = Field(
+        default=True,
+        description="Whether to output the logprobs or not. Default is True"
+    )
+    top_logprobs: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="The number of logprobs to generate. If None, no logprobs are generated. logprobs need to set to True.",
+    )
     temperature: float = temperature_field
     top_p: float = top_p_field
     min_p: float = min_p_field

--- a/llama_cpp/server/types.py
+++ b/llama_cpp/server/types.py
@@ -209,7 +209,7 @@ class CreateChatCompletionRequest(BaseModel):
         description="The maximum number of tokens to generate. Defaults to inf",
     )
     logprobs: Optional[bool] = Field(
-        default=True,
+        default=False,
         description="Whether to output the logprobs or not. Default is True"
     )
     top_logprobs: Optional[int] = Field(


### PR DESCRIPTION
Hi, this pull request is my small update/modification to add logprobs and top_logprobs arguments when creating chat completion request into llama cpp server (align with OpenAI API template).

Sample request:
POST https://host:port/v1/chat/completions
{
    "model": "mixtral-8x7b",
    "messages": [
        {
            "role": "system",
            "content": "You are a helpful assistant."
        },
        {
            "role": "user",
            "content": "Hello! Could you help me plan for 3-day trip in Hanoi?"
        }
    ],
    "logprobs": true,
    "top_logprobs": 1,
    "max_tokens": 1024,
    "temperature": 0.0001,
    "stream": false
}

Could you help me to review it? Thanks ^^