### PR TITLE
Fix incorrect tool_choice example

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,12 +458,12 @@ The high-level API supports OpenAI compatible function and tool calling. This is
           }
         }
       }],
-      tool_choice=[{
+      tool_choice={
         "type": "function",
         "function": {
           "name": "UserDetail"
         }
-      }]
+      }
 )
 ```
 


### PR DESCRIPTION
The function calling example mistakenly uses an array as tool_choice parameter.