### PR TITLE
Feature: Lightweight llama_cpp.server Docker Image Build Workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,7 @@ __pycache__/
 .Python
 build/
 develop-eggs/
-dist/
+
 downloads/
 eggs/
 .eggs/

--- a/.github/workflows/build-light-server-docker.yaml
+++ b/.github/workflows/build-light-server-docker.yaml
@@ -54,7 +54,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKER_REGISTRY }}/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=light-server
 

--- a/.github/workflows/build-light-server-docker.yaml
+++ b/.github/workflows/build-light-server-docker.yaml
@@ -10,6 +10,10 @@ jobs:
   build-light-docker:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+      packages: write
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-light-server-docker.yaml
+++ b/.github/workflows/build-light-server-docker.yaml
@@ -57,7 +57,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: docker/light-server/Dockerfile
+          context: .
+          file: "docker/light-server/Dockerfile"
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-light-server-docker.yaml
+++ b/.github/workflows/build-light-server-docker.yaml
@@ -1,0 +1,63 @@
+name: Build Light Docker
+
+on: workflow_dispatch
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-light-docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install .[all] -v
+          python3 -m pip install pyinstaller
+
+      - name: Build package
+        run: |
+          pyinstaller --onefile llama_cpp/server/__main__.py -n llama-server \
+            --add-binary "/home/runner/work/llama-cpp-python/llama-cpp-python/llama_cpp/libllama.so:./llama_cpp/" \
+            --add-binary "/home/runner/work/llama-cpp-python/llama-cpp-python/llama_cpp/libllava.so:./llama_cpp/"
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: llama-server
+          path: |
+            dist/*
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=raw,value=light-server
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: docker/light-server/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker/light-server/Dockerfile
+++ b/docker/light-server/Dockerfile
@@ -1,0 +1,4 @@
+FROM debian:12-slim
+COPY dist/ /bin/
+VOLUME ["/data/"]
+ENTRYPOINT [ "llama-server" ]


### PR DESCRIPTION
By adding this workflow, the Docker image it builds becomes more lightweight.
![image](https://github.com/abetlen/llama-cpp-python/assets/64475363/5d3c0fce-a5df-4d62-a6fc-14f8a3b67fcc)
You can see that the built image is one-tenth the size of the original image.