### PR TITLE
Update `scikit-build-core` dependency CMake error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core[pyproject]>=0.5.1"]
+requires = ["scikit-build-core[pyproject]>=0.9.2"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
The `scikit-build-core` build dependency was broken with version `0.9.1`, this change enforces the build to use the new release with the fix from:
- https://github.com/scikit-build/scikit-build-core/issues/718

Closes #1366 