### PR TITLE
Fix tokenization edge case where llama output does not start with a space

### DIFF
--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -201,7 +201,7 @@ class _LlamaModel:
         # NOTE: Llama1 models automatically added a space at the start of the prompt
         # this line removes a leading space if the first token is a beginning of sentence token
         return (
-            output[1:] if len(tokens) > 0 and tokens[0] == self.token_bos() else output
+            output[1:] if len(tokens) > 0 and tokens[0] == self.token_bos() and output[0:1] == ' ' else output
         )
 
     # Extra


### PR DESCRIPTION
Created following investigation in this issue:
https://github.com/noamgat/lm-format-enforcer/issues/92

See this notebook for a reproduction of the problem:
https://colab.research.google.com/drive/1Ooz11nFPk19zyJdMDx42CeesU8aWZMdI#scrollTo=oKpHw5PZ30uC

When using the model
`TheBloke/tinyllama-1.1b-chat-v1.0-GGUF`

In the current implementation, the token sequence `[6377]` decodes to `{"` while the token sequence `[1,6377]` decodes to `"`. This is because the LLama tokenizer doesn't add a leading space when decoding this sequence, but the llama-cpp-python code that wraps it assumes that it does.
This breaks that assumption, and only returns `output[1:]` instead of `output` when the first character is a space.

Implementation note: I made the check `output[0:1] == ' '` and not `output[0] == ' '` to avoid edge cases where the output is empty (maybe if the first tokens are partial unicode characters).