### PR TITLE
Allow for possibly non-pooled embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ llama = Llama(
 
 ### Embeddings
 
-To generate text embeddings use [`create_embedding`](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#llama_cpp.Llama.create_embedding).
+To generate text embeddings use [`create_embedding`](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#llama_cpp.Llama.create_embedding) or [`embed`](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#llama_cpp.Llama.embed). Note that you must pass `embedding=True` to the constructor upon model creation for these to work properly.
 
 ```python
 import llama_cpp
@@ -588,6 +588,12 @@ embeddings = llm.create_embedding("Hello, world!")
 
 embeddings = llm.create_embedding(["Hello, world!", "Goodbye, world!"])
 ```
+
+There are two primary notions of embeddings in a Transformer-style model: *token level* and *sequence level*. Sequence level embeddings are produced by "pooling" token level embeddings together, usually by averaging them or using the first token.
+
+Models that are explicitly geared towards embeddings will usually return sequence level embeddings by default, one for each input string. Non-embedding models such as those designed for text generation will typically return only token level embeddings, one for each token in each sequence. Thus the dimensionality of the return type will be one higher for token level embeddings.
+
+It is possible to control pooling behavior in some cases using the `pooling_type` flag on model creation. You can ensure token level embeddings from any model using `LLAMA_POOLING_TYPE_NONE`. The reverse, getting a generation oriented model to yield sequence level embeddings is currently not possible, but you can always do the pooling manually.
 
 ### Adjusting the Context Window
 

--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -273,6 +273,10 @@ class _LlamaContext:
         assert self.ctx is not None
         return llama_cpp.llama_n_ctx(self.ctx)
 
+    def pooling_type(self) -> int:
+        assert self.ctx is not None
+        return llama_cpp.llama_pooling_type(self.ctx)
+
     def kv_cache_clear(self):
         assert self.ctx is not None
         llama_cpp.llama_kv_cache_clear(self.ctx)
@@ -639,6 +643,16 @@ def _should_add_bos(model: _LlamaModel) -> bool:
         return add_bos != 0
     else:
         return llama_cpp.llama_vocab_type(model.model) == llama_cpp.LLAMA_VOCAB_TYPE_SPM
+
+
+# Embedding functions
+
+
+def _normalize_embedding(embedding):
+    norm = float(np.linalg.norm(embedding))
+    if norm == 0.0:
+        return embedding
+    return [v / norm for v in embedding]
 
 
 # Python wrappers over common/sampling structs

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -1179,6 +1179,12 @@ def llama_rope_type(model: llama_model_p, /) -> int:
     ...
 
 
+# LLAMA_API enum llama_pooling_type llama_pooling_type(const struct llama_model * model);
+@ctypes_function("llama_pooling_type", [llama_model_p_ctypes], ctypes.c_int)
+def llama_pooling_type(model: llama_model_p, /) -> int:
+    ...
+
+
 # LLAMA_API int32_t llama_n_vocab    (const struct llama_model * model);
 @ctypes_function("llama_n_vocab", [llama_model_p_ctypes], ctypes.c_int32)
 def llama_n_vocab(model: llama_model_p, /) -> int:

--- a/llama_cpp/llama_types.py
+++ b/llama_cpp/llama_types.py
@@ -24,7 +24,7 @@ class EmbeddingUsage(TypedDict):
 class Embedding(TypedDict):
     index: int
     object: str
-    embedding: List[float]
+    embedding: Union[List[float], List[List[float]]]
 
 
 class CreateEmbeddingResponse(TypedDict):


### PR DESCRIPTION
Getting embeddings direct from "non-embedding" LLMs is pretty important for achieving SOTA performance (see [MTEB Leaderboard](https://huggingface.co/spaces/mteb/leaderboard)). This PR makes it so that the embed functions return token level embeddings when the `pooling_type` ends up being `LLAMA_POOLING_TYPE_NONE` and the appropriate sequence level embeddings otherwise. After that, the user can do whatever type of pooling they wish. This should address most of the concerns raised in #1288 too.

There are still some gotchas. If you request mean/cls pooling on a model that doesn't support it, it will hard crash in `llama.cpp`. And it's hard to know ex ante what types of pooling a model supports. So it's probably just better to wait until this gets sorted out in `llama.cpp`.

Also, this changes the default for `normalize` to `False`. You typically want to normalize after pooling, so you would not want to normalize when getting token level embeddings. The other option is defaulting to `False` for token level and `True` for sequence level, but that seems overly complicated.

*Note*: this depends on the `llama_pooling_type` function, which just got merged in https://github.com/ggerganov/llama.cpp/commit/b4e4b8a9351d918a56831c73cf9f25c1837b80d1.