### PR TITLE
Functionary bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,8 @@ Due to discrepancies between llama.cpp and HuggingFace's tokenizers, it is requi
   tokenizer=LlamaHFTokenizer.from_pretrained("meetkai/functionary-small-v2.2-GGUF")
 )
 ```
+
+**NOTE**: There is no need to provide the default system messages used in Functionary as they are added automatically in the Functionary chat handler. Thus, the messages should contain just the chat messages and/or system messages that provide additional context for the model (e.g.: datetime, etc.).
 </details>
 
 ### Multi-modal Models

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -2131,13 +2131,15 @@ def functionary_v1_v2_chat_handler(
         )
 
     # TODO: support stream mode
-    function_call_dict: Union[Dict[str, str], Dict[Literal["function_call"], llama_types.ChatCompletionRequestAssistantMessageFunctionCall]] = { 
-        "function_call": {
-            "name": tool_calls[0]["function"]["name"],
-            "arguments": tool_calls[0]["function"]["arguments"],
-        } if len(tool_calls) > 0 and tools is None else None,
-        "tool_calls": tool_calls if len(tool_calls) > 0 and tools is not None else None,
-    } 
+    function_call_dict: Union[Dict[str, str], Dict[Literal["function_call"], llama_types.ChatCompletionRequestAssistantMessageFunctionCall]] = {}
+    if len(tool_calls) > 0:
+        if tools is not None:
+            function_call_dict["tool_calls"] = tool_calls
+        else:
+            function_call_dict["function_call"] = {
+                "name": tool_calls[0]["function"]["name"],
+                "arguments": tool_calls[0]["function"]["arguments"],
+            }
     completion["usage"]["completion_tokens"] = completion_tokens
     return llama_types.CreateChatCompletionResponse(
         id="chat" + completion["id"],
@@ -2151,7 +2153,6 @@ def functionary_v1_v2_chat_handler(
                 "message": {
                     "role": "assistant",
                     "content": None if content == "" else content,
-                    "tool_calls": tool_calls if tools is not None else None,
                     **function_call_dict,
                 },
                 "finish_reason": "tool_calls" if len(tool_calls) > 0 else "stop",


### PR DESCRIPTION
- Implement tracking of number of completion tokens (Closes #1344 )
- Fixes the bug that resulted in both `function_call` and `tool_calls` returning function/tool calls. Now, when `tools` are provided and function calls are invoked, only `tool_calls` will return the calls while `function_call` will be None, vice versa for `functions`. (Addresses [this issue](https://github.com/MeetKai/functionary/issues/156))
- Fixes functionary chat handler incompatibility with Python 3.8 (Closes #1361 )
- Adjusted README

Streaming implementation in progress currently and will be in a future PR.