### PR TITLE
fix: add binding for name in ChatCompletionRequestToolMessage

### DIFF
--- a/llama_cpp/llama_types.py
+++ b/llama_cpp/llama_types.py
@@ -222,6 +222,7 @@ class ChatCompletionRequestToolMessage(TypedDict):
     role: Literal["tool"]
     content: Optional[str]
     tool_call_id: str
+    name: Optional[str]
 
 
 class ChatCompletionRequestFunctionMessage(TypedDict):


### PR DESCRIPTION
Follow issue #1405