### PR TITLE
Fix: Propagate flash attn to model loader

### DIFF
--- a/llama_cpp/server/model.py
+++ b/llama_cpp/server/model.py
@@ -242,6 +242,7 @@ class LlamaProxy:
             logits_all=settings.logits_all,
             embedding=settings.embedding,
             offload_kqv=settings.offload_kqv,
+            flash_attn=settings.flash_attn,
             # Sampling Params
             last_n_tokens_size=settings.last_n_tokens_size,
             # LoRA Params


### PR DESCRIPTION
I noticed that even though setting `flash_attn` to `true` in my model config file, `llama.cpp` kept reporting `llama_new_context_with_model: flash_attn = 0`. This super-small PR fixes that - turns out the setting wasn't passed on to the model loader.