### PR TITLE
Fix chat_format log

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -451,7 +451,7 @@ class Llama:
         if self.chat_format is None and self.chat_handler is None:
             self.chat_format = "llama-2"
             if self.verbose:
-                print(f"Using fallback chat format: {chat_format}", file=sys.stderr)
+                print(f"Using fallback chat format: {self.chat_format}", file=sys.stderr)
 
     @property
     def ctx(self) -> llama_cpp.llama_context_p:


### PR DESCRIPTION
Currently the log prints `None`.