### PR TITLE
Avoid duplicate special tokens in chat formats

### DIFF
--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -170,14 +170,6 @@ class _LlamaModel:
         assert self.model is not None
         return llama_cpp.llama_token_eot(self.model)
 
-    def add_bos_token(self) -> int:
-        assert self.model is not None
-        return llama_cpp.llama_add_bos_token(self.model)
-
-    def add_eos_token(self) -> int:
-        assert self.model is not None
-        return llama_cpp.llama_add_eos_token(self.model)
-
     # Tokenization
 
     def tokenize(self, text: bytes, add_bos: bool, special: bool):

--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -142,6 +142,14 @@ class _LlamaModel:
         assert self.model is not None
         return llama_cpp.llama_token_eos(self.model)
 
+    def token_cls(self) -> int:
+        assert self.model is not None
+        return llama_cpp.llama_token_cls(self.model)
+
+    def token_sep(self) -> int:
+        assert self.model is not None
+        return llama_cpp.llama_token_sep(self.model)
+
     def token_nl(self) -> int:
         assert self.model is not None
         return llama_cpp.llama_token_nl(self.model)
@@ -161,6 +169,14 @@ class _LlamaModel:
     def token_eot(self) -> int:
         assert self.model is not None
         return llama_cpp.llama_token_eot(self.model)
+
+    def add_bos_token(self) -> int:
+        assert self.model is not None
+        return llama_cpp.llama_add_bos_token(self.model)
+
+    def add_eos_token(self) -> int:
+        assert self.model is not None
+        return llama_cpp.llama_add_eos_token(self.model)
 
     # Tokenization
 

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1016,7 +1016,7 @@ class Llama:
         )
         model_name: str = model if model is not None else self.model_path
 
-        # User or template may have added an unwanted extra BOS
+        # User may have added an unwanted extra BOS
         if prompt_tokens[:2] == [self.token_bos()] * 2:
             del prompt_tokens[0]
 

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1016,9 +1016,8 @@ class Llama:
         )
         model_name: str = model if model is not None else self.model_path
 
-        # User may have added an unwanted extra BOS
         if prompt_tokens[:2] == [self.token_bos()] * 2:
-            del prompt_tokens[0]
+            print(f'*** WARNING: Detected duplicate leading "{self._model.token_get_text(self.token_bos())}" in prompt, this will likely reduce response quality, consider removing it...', file=sys.stderr)
 
         # NOTE: This likely doesn't work correctly for the first token in the prompt
         # because of the extra space added to the start of the prompt_tokens

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -8,6 +8,7 @@ import json
 import ctypes
 import typing
 import fnmatch
+import warnings
 import multiprocessing
 
 from typing import (
@@ -1020,7 +1021,10 @@ class Llama:
         model_name: str = model if model is not None else self.model_path
 
         if prompt_tokens[:2] == [self.token_bos()] * 2:
-            print(f'*** WARNING: Detected duplicate leading "{self._model.token_get_text(self.token_bos())}" in prompt, this will likely reduce response quality, consider removing it...', file=sys.stderr)
+            warnings.warn(
+                f'Detected duplicate leading "{self._model.token_get_text(self.token_bos())}" in prompt, this will likely reduce response quality, consider removing it...',
+                RuntimeWarning,
+            )
 
         # NOTE: This likely doesn't work correctly for the first token in the prompt
         # because of the extra space added to the start of the prompt_tokens

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1016,6 +1016,10 @@ class Llama:
         )
         model_name: str = model if model is not None else self.model_path
 
+        # User or template may have added an unwanted extra BOS
+        if prompt_tokens[:2] == [self.token_bos()] * 2:
+            del prompt_tokens[0]
+
         # NOTE: This likely doesn't work correctly for the first token in the prompt
         # because of the extra space added to the start of the prompt_tokens
         if logit_bias is not None:

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -159,6 +159,7 @@ class ChatFormatterResponse:
     prompt: str
     stop: Optional[Union[str, List[str]]] = None
     stopping_criteria: Optional[llama.StoppingCriteriaList] = None
+    added_special: bool = False
 
 
 class ChatFormatter(Protocol):
@@ -231,7 +232,7 @@ class Jinja2ChatFormatter(ChatFormatter):
                 return tokens[-1] in self.stop_token_ids
             stopping_criteria = llama.StoppingCriteriaList([stop_on_last_token])
 
-        return ChatFormatterResponse(prompt=prompt, stop=[self.eos_token], stopping_criteria=stopping_criteria)
+        return ChatFormatterResponse(prompt=prompt, stop=[self.eos_token], stopping_criteria=stopping_criteria, added_special=True)
 
     def to_chat_handler(self) -> LlamaChatCompletionHandler:
         return chat_formatter_to_chat_completion_handler(self)
@@ -547,7 +548,11 @@ def chat_formatter_to_chat_completion_handler(
             tools=tools,
             tool_choice=tool_choice,
         )
-        prompt = llama.tokenize(result.prompt.encode("utf-8"), add_bos=False, special=True)
+
+        prompt = [llama.token_bos()] if not result.added_special and llama._model.add_bos_token() != 0 else []
+        prompt += llama.tokenize(result.prompt.encode("utf-8"), add_bos=False, special=True)
+        prompt += [llama.token_eos()] if not result.added_special and llama._model.vocab_type() == 1 and llama._model.add_eos_token() != 0 else []
+
         if result.stop is not None:
             stop = [] if stop is None else [stop] if isinstance(stop, str) else stop
             rstop = result.stop if isinstance(result.stop, list) else [result.stop]
@@ -654,7 +659,7 @@ def hf_autotokenizer_to_chat_formatter(
         prompt: str = tokenizer.apply_chat_template(messages, tokenize=False)  # type: ignore
         assert isinstance(prompt, str)
         # Return formatted prompt and eos token by default
-        return ChatFormatterResponse(prompt=prompt, stop=tokenizer.eos_token)
+        return ChatFormatterResponse(prompt=prompt, stop=tokenizer.eos_token, added_special=True)
 
     return format_autotokenizer
 
@@ -708,7 +713,7 @@ def hf_tokenizer_config_to_chat_formatter(
             bos_token=bos_token,
             eos_token=eos_token,
         )
-        return ChatFormatterResponse(prompt=prompt, stop=[eos_token, bos_token])
+        return ChatFormatterResponse(prompt=prompt, stop=[eos_token, bos_token], added_special=True)
 
     return format_tokenizer_config
 
@@ -918,7 +923,7 @@ def format_llama2(
     messages: List[llama_types.ChatCompletionRequestMessage],
     **kwargs: Any,
 ) -> ChatFormatterResponse:
-    _system_template = "<s>[INST] <<SYS>>\n{system_message}\n<</SYS>>"
+    _system_template = "[INST] <<SYS>>\n{system_message}\n<</SYS>>"
     _roles = dict(user="<s>[INST]", assistant="[/INST]")
     _messages = _map_roles(messages, _roles)
     system_message = _get_system_message(messages)
@@ -940,11 +945,10 @@ def format_llama3(
         user="<|start_header_id|>user<|end_header_id|>\n\n",
         assistant="<|start_header_id|>assistant<|end_header_id|>\n\n",
     )
-    _begin_token = "<|begin_of_text|>"
     _sep = "<|eot_id|>"
     _messages = _map_roles(messages, _roles)
     _messages.append((_roles["assistant"], None))
-    _prompt = _format_no_colon_single(_begin_token, _messages, _sep)
+    _prompt = _format_no_colon_single("", _messages, _sep)
     return ChatFormatterResponse(prompt=_prompt, stop=_sep)
 
 
@@ -958,7 +962,7 @@ def format_alpaca(
     _sep2 = "</s>"
     system_message = _get_system_message(messages)
     _messages = _map_roles(messages, _roles)
-    _prompt = "<s>" + _format_add_colon_two(system_message, _messages, _sep, _sep2)
+    _prompt = _format_add_colon_two(system_message, _messages, _sep, _sep2)
     return ChatFormatterResponse(prompt=_prompt)
 
 
@@ -991,7 +995,7 @@ def format(
     system_message = _system_message
     _messages = _map_roles(messages, _roles)
     _messages.append((_roles["assistant"], None))
-    _prompt = "<s>" + _format_add_colon_two(system_message, _messages, _sep, _sep2)
+    _prompt = _format_add_colon_two(system_message, _messages, _sep, _sep2)
     return ChatFormatterResponse(prompt=_prompt)
 
 
@@ -1007,7 +1011,7 @@ def format_oasst_llama(
     system_message = _system_template.format(system_message=system_message)
     _messages = _map_roles(messages, _roles)
     _messages.append((_roles["assistant"], None))
-    _prompt = "<s>" + _format_no_colon_single(system_message, _messages, _sep)
+    _prompt = _format_no_colon_single(system_message, _messages, _sep)
     return ChatFormatterResponse(prompt=_prompt)
 
 
@@ -1229,10 +1233,9 @@ def format_mistral_instruct(
     messages: List[llama_types.ChatCompletionRequestMessage],
     **kwargs: Any,
 ) -> ChatFormatterResponse:
-    bos = "<s>"
     eos = "</s>"
     stop = eos
-    prompt = bos
+    prompt = ""
     for message in messages:
         if (
             message["role"] == "user"
@@ -1280,7 +1283,7 @@ def format_openchat(
     _sep = "<|end_of_turn|>"
     _messages = _map_roles(messages, _roles)
     _messages.append((_roles["assistant"], None))
-    _prompt = "<s>" + _format_chatml(system_message, _messages, _sep)
+    _prompt = _format_chatml(system_message, _messages, _sep)
     return ChatFormatterResponse(prompt=_prompt, stop=_sep)
 
 

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -1187,7 +1187,7 @@ def format_zephyr(
     _sep = "</s>"
     _messages = _map_roles(messages, _roles)
     _messages.append((_roles["assistant"], None))
-    _prompt = "<s>" + _format_chatml(system_message, _messages, _sep)
+    _prompt = _format_chatml(system_message, _messages, _sep)
     return ChatFormatterResponse(prompt=_prompt, stop=_sep)
 
 
@@ -1262,7 +1262,7 @@ def format_chatglm3(
     _sep = "</s>"
     _messages = _map_roles(messages, _roles)
     _messages.append((_roles["assistant"], None))
-    _prompt = "<s>" + _format_chatglm3(system_message, _messages, _sep)
+    _prompt = _format_chatglm3(system_message, _messages, _sep)
     return ChatFormatterResponse(prompt=_prompt, stop=_sep)
 
 
@@ -1280,7 +1280,7 @@ def format_openchat(
     _sep = "<|end_of_turn|>"
     _messages = _map_roles(messages, _roles)
     _messages.append((_roles["assistant"], None))
-    _prompt = _format_chatml(system_message, _messages, _sep)
+    _prompt = "<s>" + _format_chatml(system_message, _messages, _sep)
     return ChatFormatterResponse(prompt=_prompt, stop=_sep)
 
 

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -548,7 +548,7 @@ def chat_formatter_to_chat_completion_handler(
             tools=tools,
             tool_choice=tool_choice,
         )
-        prompt += llama.tokenize(result.prompt.encode("utf-8"), add_bos=not result.added_special, special=True)
+        prompt = llama.tokenize(result.prompt.encode("utf-8"), add_bos=not result.added_special, special=True)
         if result.stop is not None:
             stop = [] if stop is None else [stop] if isinstance(stop, str) else stop
             rstop = result.stop if isinstance(result.stop, list) else [result.stop]

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -547,7 +547,7 @@ def chat_formatter_to_chat_completion_handler(
             tools=tools,
             tool_choice=tool_choice,
         )
-        prompt = result.prompt
+        prompt = llama.tokenize(result.prompt.encode("utf-8"), add_bos=False, special=True)
         if result.stop is not None:
             stop = [] if stop is None else [stop] if isinstance(stop, str) else stop
             rstop = result.stop if isinstance(result.stop, list) else [result.stop]
@@ -958,7 +958,7 @@ def format_alpaca(
     _sep2 = "</s>"
     system_message = _get_system_message(messages)
     _messages = _map_roles(messages, _roles)
-    _prompt = _format_add_colon_two(system_message, _messages, _sep, _sep2)
+    _prompt = "<s>" + _format_add_colon_two(system_message, _messages, _sep, _sep2)
     return ChatFormatterResponse(prompt=_prompt)
 
 
@@ -991,7 +991,7 @@ def format(
     system_message = _system_message
     _messages = _map_roles(messages, _roles)
     _messages.append((_roles["assistant"], None))
-    _prompt = _format_add_colon_two(system_message, _messages, _sep, _sep2)
+    _prompt = "<s>" + _format_add_colon_two(system_message, _messages, _sep, _sep2)
     return ChatFormatterResponse(prompt=_prompt)
 
 
@@ -1007,7 +1007,7 @@ def format_oasst_llama(
     system_message = _system_template.format(system_message=system_message)
     _messages = _map_roles(messages, _roles)
     _messages.append((_roles["assistant"], None))
-    _prompt = _format_no_colon_single(system_message, _messages, _sep)
+    _prompt = "<s>" + _format_no_colon_single(system_message, _messages, _sep)
     return ChatFormatterResponse(prompt=_prompt)
 
 
@@ -1187,7 +1187,7 @@ def format_zephyr(
     _sep = "</s>"
     _messages = _map_roles(messages, _roles)
     _messages.append((_roles["assistant"], None))
-    _prompt = _format_chatml(system_message, _messages, _sep)
+    _prompt = "<s>" + _format_chatml(system_message, _messages, _sep)
     return ChatFormatterResponse(prompt=_prompt, stop=_sep)
 
 
@@ -1262,7 +1262,7 @@ def format_chatglm3(
     _sep = "</s>"
     _messages = _map_roles(messages, _roles)
     _messages.append((_roles["assistant"], None))
-    _prompt = _format_chatglm3(system_message, _messages, _sep)
+    _prompt = "<s>" + _format_chatglm3(system_message, _messages, _sep)
     return ChatFormatterResponse(prompt=_prompt, stop=_sep)
 
 

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -548,11 +548,7 @@ def chat_formatter_to_chat_completion_handler(
             tools=tools,
             tool_choice=tool_choice,
         )
-
-        prompt = [llama.token_bos()] if not result.added_special and llama._model.add_bos_token() != 0 else []
-        prompt += llama.tokenize(result.prompt.encode("utf-8"), add_bos=False, special=True)
-        prompt += [llama.token_eos()] if not result.added_special and llama._model.vocab_type() == 1 and llama._model.add_eos_token() != 0 else []
-
+        prompt += llama.tokenize(result.prompt.encode("utf-8"), add_bos=not result.added_special, special=True)
         if result.stop is not None:
             stop = [] if stop is None else [stop] if isinstance(stop, str) else stop
             rstop = result.stop if isinstance(result.stop, list) else [result.stop]

--- a/tests/test_llama_chat_format.py
+++ b/tests/test_llama_chat_format.py
@@ -21,12 +21,13 @@ def test_mistral_instruct():
     response = llama_chat_format.format_mistral_instruct(
         messages=messages,
     )
+    prompt = ("" if response.added_special else "<s>") + response.prompt
     reference = chat_formatter.render(
         messages=messages,
         bos_token="<s>",
         eos_token="</s>",
     )
-    assert response.prompt == reference
+    assert prompt == reference
 
 
 mistral_7b_tokenizer_config = """{


### PR DESCRIPTION
Having multiple BOS can ruin generation, this would occur in several ways, usually through user adding them unnecessarily, in this case output a warning if we detect two in a row.

However, several formats/templates also have BOS in them, and we would add another one later in completion, therefore tokenize format/template prompts before completion to avoid this.

Added a new `added_special` property to `ChatFormatterResponse` to detect when BOS/EOS has already been added to prompt.

Also added missing `token_cls`, `token_sep`, ~~`add_bos_token` and `add_eos_token`~~ to `_LlamaModel` because I thought I needed them (turns out I didn't).

Fixes #1501