### PR TITLE
Support multiple chat templates - step 2

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1689,6 +1689,7 @@ class Llama:
         logit_bias: Optional[Dict[str, float]] = None,
         logprobs: Optional[bool] = None,
         top_logprobs: Optional[int] = None,
+        template_kwargs: Optional[Dict[str, Any]] = None,
     ) -> Union[
         CreateChatCompletionResponse, Iterator[CreateChatCompletionStreamResponse]
     ]:
@@ -1721,6 +1722,7 @@ class Llama:
             logits_processor: A list of logits processors to use.
             grammar: A grammar to use.
             logit_bias: A logit bias to use.
+            template_kwargs: Optional dictionary of arguments to pass to chat template.
 
         Returns:
             Generated chat completion or a stream of chat completion chunks.
@@ -1758,6 +1760,7 @@ class Llama:
             logits_processor=logits_processor,
             grammar=grammar,
             logit_bias=logit_bias,
+            template_kwargs=template_kwargs,
         )
 
     def create_chat_completion_openai_v1(

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -205,10 +205,14 @@ class Jinja2ChatFormatter(ChatFormatter):
         function_call: Optional[llama_types.ChatCompletionRequestFunctionCall] = None,
         tools: Optional[List[llama_types.ChatCompletionTool]] = None,
         tool_choice: Optional[llama_types.ChatCompletionToolChoiceOption] = None,
+        template_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> ChatFormatterResponse:
         def raise_exception(message: str):
             raise ValueError(message)
+
+        if template_kwargs is None:
+            template_kwargs = {}
 
         prompt = self._environment.render(
             messages=messages,
@@ -220,6 +224,7 @@ class Jinja2ChatFormatter(ChatFormatter):
             function_call=function_call,
             tools=tools,
             tool_choice=tool_choice,
+            **template_kwargs,
         )
 
         stopping_criteria = None
@@ -535,6 +540,7 @@ def chat_formatter_to_chat_completion_handler(
         logit_bias: Optional[Dict[str, float]] = None,
         logprobs: Optional[bool] = None,
         top_logprobs: Optional[int] = None,
+        template_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,  # type: ignore
     ) -> Union[
         llama_types.CreateChatCompletionResponse,
@@ -546,6 +552,7 @@ def chat_formatter_to_chat_completion_handler(
             function_call=function_call,
             tools=tools,
             tool_choice=tool_choice,
+            template_kwargs=template_kwargs,
         )
         prompt = result.prompt
         if result.stop is not None:


### PR DESCRIPTION
Next step towards #1336 adds a new parameter to be able to pass arbitrary arguments to the template, much like transformers, except through an explicit parameter instead of just plain kwargs.