### PR TITLE
Support SPM infill

### DIFF
--- a/examples/high_level_api/high_level_api_infill.py
+++ b/examples/high_level_api/high_level_api_infill.py
@@ -1,0 +1,33 @@
+import argparse
+
+from llama_cpp import Llama
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-m", "--model", type=str, default="../models/7B/ggml-models.bin")
+parser.add_argument("-p", "--prompt", type=str, default="def add(")
+parser.add_argument("-s", "--suffix", type=str, default="\n    return sum\n\n")
+parser.add_argument("-i", "--spm-infill", action='store_true')
+args = parser.parse_args()
+
+llm = Llama(model_path=args.model, n_gpu_layers=-1, spm_infill=args.spm_infill)
+
+output = llm.create_completion(
+      temperature = 0.0,
+      repeat_penalty = 1.0,
+      prompt = args.prompt,
+      suffix = args.suffix,
+)
+
+# Models sometimes repeat suffix in response, attempt to filter that
+response = output["choices"][0]["text"]
+response_stripped = response.rstrip()
+unwanted_response_suffix = args.suffix.rstrip()
+unwanted_response_length = len(unwanted_response_suffix)
+
+filtered = False
+if unwanted_response_suffix and response_stripped[-unwanted_response_length:] == unwanted_response_suffix:
+    response = response_stripped[:-unwanted_response_length]
+    filtered = True
+
+print(f"Fill-in-Middle completion{' (filtered)' if filtered else ''}:\n\n{args.prompt}\033[32m{response}\033[0m{args.suffix}")
+

--- a/examples/high_level_api/high_level_api_infill.py
+++ b/examples/high_level_api/high_level_api_infill.py
@@ -29,5 +29,5 @@ if unwanted_response_suffix and response_stripped[-unwanted_response_length:] ==
     response = response_stripped[:-unwanted_response_length]
     filtered = True
 
-print(f"Fill-in-Middle completion{' (filtered)' if filtered else ''}:\n\n{args.prompt}\033[32m{response}\033[0m{args.suffix}")
+print(f"Fill-in-Middle completion{' (filtered)' if filtered else ''}:\n\n{args.prompt}\033[32m{response}\033[{'33' if filtered else '0'}m{args.suffix}\033[0m")
 

--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -162,6 +162,14 @@ class _LlamaModel:
         assert self.model is not None
         return llama_cpp.llama_token_eot(self.model)
 
+    def add_bos_token(self) -> int:
+        assert self.model is not None
+        return llama_cpp.llama_add_bos_token(self.model)
+
+    def add_eos_token(self) -> int:
+        assert self.model is not None
+        return llama_cpp.llama_add_eos_token(self.model)
+
     # Tokenization
 
     def tokenize(self, text: bytes, add_bos: bool, special: bool):

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -983,14 +983,14 @@ class Llama:
         middle_token_id: int = self._model.token_middle()
         suffix_token_id: int = self._model.token_suffix()
         add_space_prefix: bool = self.metadata.get("tokenizer.ggml.add_space_prefix", "true") == "true"
-        bos_tokens: List[int] = [bos_token_id] if not (isinstance(prompt, list) and suffix is None) and self._model.add_bos_token() != 0 and bos_token_id >= 0 else []
-        eos_tokens: List[int] = [self.token_eos()] if not (isinstance(prompt, list) and suffix is None) and self._model.add_eos_token() == 1 else []
+        bos_tokens: List[int] = [cls_token_id if cls_token_id != -1 else bos_token_id]
+        eos_tokens: List[int] = [sep_token_id if sep_token_id != -1 else self.token_eos()]
 
-        if cls_token_id != -1:
-            bos_tokens = [cls_token_id]
+        if (isinstance(prompt, list) and suffix is None) or self._model.add_bos_token() == 0 or bos_tokens[:1] == [-1]:
+            bos_tokens = []
 
-        if sep_token_id != -1:
-            eos_tokens = [sep_token_id]
+        if (isinstance(prompt, list) and suffix is None) or (self._model.add_eos_token() != 1 and sep_token_id == -1):
+            eos_tokens = []
 
         suffix_space_prefix: int = 0
         # Tokenizer hack to remove leading space

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -998,18 +998,16 @@ class Llama:
         )
         suffix_tokens: List[int] = (
             (
+                [suffix_token_id]
+                +
                 (
-                    [suffix_token_id]
-                    +
-                    (
-                        self.tokenize(suffix.encode("utf-8"), add_bos=False, special=False)
-                        if suffix
-                        else []
-                    )
+                    self.tokenize(suffix.encode("utf-8"), add_bos=False, special=False)
+                    if suffix
+                    else []
                 )
-                if suffix_token_id >= 0 and suffix is not None
-                else []
             )
+            if suffix_token_id >= 0 and suffix is not None
+            else []
         )
         middle_tokens: List[int] = (
             [middle_token_id]

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -977,12 +977,20 @@ class Llama:
         completion_id: str = f"cmpl-{str(uuid.uuid4())}"
         created: int = int(time.time())
         bos_token_id: int = self.token_bos()
+        cls_token_id: int = self._model.token_cls()
+        sep_token_id: int = self._model.token_sep()
         prefix_token_id: int = self._model.token_prefix()
         middle_token_id: int = self._model.token_middle()
         suffix_token_id: int = self._model.token_suffix()
         add_space_prefix: bool = self.metadata.get("tokenizer.ggml.add_space_prefix", "true") == "true"
         bos_tokens: List[int] = [bos_token_id] if not (isinstance(prompt, list) and suffix is None) and self._model.add_bos_token() != 0 and bos_token_id >= 0 else []
         eos_tokens: List[int] = [self.token_eos()] if not (isinstance(prompt, list) and suffix is None) and self._model.add_eos_token() == 1 else []
+
+        if cls_token_id != -1:
+            bos_tokens = [cls_token_id]
+
+        if sep_token_id != -1:
+            eos_tokens = [sep_token_id]
 
         suffix_space_prefix: int = 0
         # Tokenizer hack to remove leading space

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -971,7 +971,7 @@ class Llama:
         prefix_token_id: int = self._model.token_prefix()
         middle_token_id: int = self._model.token_middle()
         suffix_token_id: int = self._model.token_suffix()
-        add_space_prefix: bool = self.metadata.get("tokenizer.ggml.add_space_prefix", True)
+        add_space_prefix: bool = self.metadata.get("tokenizer.ggml.add_space_prefix", "true") == "true"
         bos_tokens: List[int] = [self.token_bos()] if not (isinstance(prompt, list) and suffix is None) and self._model.add_bos_token() != 0 else []
         eos_tokens: List[int] = [self.token_eos()] if not (isinstance(prompt, list) and suffix is None) and self._model.add_eos_token() == 1 else []
 

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1016,7 +1016,7 @@ class Llama:
             if middle_token_id >= 0 and suffix is not None
             else []
         )
-        prompt_tokens: List[int] = (suffix_tokens + prefix_tokens + middle_tokens) if spm_infill else (prefix_tokens + suffix_tokens + middle_tokens)
+        prompt_tokens: List[int] = (suffix_tokens + prefix_tokens + middle_tokens) if self.spm_infill else (prefix_tokens + suffix_tokens + middle_tokens)
         text: bytes = b""
         returned_tokens: int = 0
         stop = (

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -971,8 +971,8 @@ class Llama:
         prefix_token_id: int = self._model.token_prefix()
         middle_token_id: int = self._model.token_middle()
         suffix_token_id: int = self._model.token_suffix()
-        bos_tokens: List[int] = [self.token_bos()] if self._model.add_bos_token() != 0 else []
-        eos_tokens: List[int] = [self.token_eos()] if self._model.add_eos_token() == 1 else []
+        bos_tokens: List[int] = [self.token_bos()] if not (isinstance(prompt, list) and suffix is None) and self._model.add_bos_token() != 0 else []
+        eos_tokens: List[int] = [self.token_eos()] if not (isinstance(prompt, list) and suffix is None) and self._model.add_eos_token() == 1 else []
         # If prompt is empty, initialize completion with BOS token to avoid
         # detokenization including a space at the beginning of the completion
         completion_tokens: List[int] = [] if len(prompt) > 0 else [self.token_bos()]

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -971,7 +971,7 @@ class Llama:
         prefix_token_id: int = self._model.token_prefix()
         middle_token_id: int = self._model.token_middle()
         suffix_token_id: int = self._model.token_suffix()
-        bos_tokens: List[int] = [self.token_bos()] if self._model.add_bos_token() == 1 else []
+        bos_tokens: List[int] = [self.token_bos()] if self._model.add_bos_token() != 0 else []
         eos_tokens: List[int] = [self.token_eos()] if self._model.add_eos_token() == 1 else []
         # If prompt is empty, initialize completion with BOS token to avoid
         # detokenization including a space at the beginning of the completion


### PR DESCRIPTION
Add `spm_infill` option to perform infill in the Suffix/Prefix/Middle pattern instead of Prefix/Suffix/Middle as some models (like the new `Codestral`) prefer this.

Also added a tokenizer hack to remove leading space in suffix to improve inference, tested on several different tokenizers/vocabs with success.