### PR TITLE
Disable Windows+CUDA workaround when compiling for HIPBLAS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if (LLAMA_BUILD)
         RESOURCE DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/llama_cpp
     )
     # Workaround for Windows + CUDA https://github.com/abetlen/llama-cpp-python/issues/563
-    if (NOT LLAMA_HIPBLAS)
+    if (WIN32 AND (LLAMA_CUDA OR LLAMA_CUBLAS))
         install(
             FILES $<TARGET_RUNTIME_DLLS:llama>
             DESTINATION ${SKBUILD_PLATLIB_DIR}/llama_cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,14 +41,16 @@ if (LLAMA_BUILD)
         RESOURCE DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/llama_cpp
     )
     # Workaround for Windows + CUDA https://github.com/abetlen/llama-cpp-python/issues/563
-    install(
-        FILES $<TARGET_RUNTIME_DLLS:llama>
-        DESTINATION ${SKBUILD_PLATLIB_DIR}/llama_cpp
-    )
-    install(
-        FILES $<TARGET_RUNTIME_DLLS:llama>
-        DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/llama_cpp
-    )
+    if(NOT LLAMA_HIPBLAS)
+        install(
+            FILES $<TARGET_RUNTIME_DLLS:llama>
+            DESTINATION ${SKBUILD_PLATLIB_DIR}/llama_cpp
+        )
+        install(
+            FILES $<TARGET_RUNTIME_DLLS:llama>
+            DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/llama_cpp
+        )
+    endif()
 
     if (LLAVA_BUILD)
         if (LLAMA_CUBLAS OR LLAMA_CUDA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if (LLAMA_BUILD)
         RESOURCE DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/llama_cpp
     )
     # Workaround for Windows + CUDA https://github.com/abetlen/llama-cpp-python/issues/563
-    if(NOT LLAMA_HIPBLAS)
+    if (NOT LLAMA_HIPBLAS)
         install(
             FILES $<TARGET_RUNTIME_DLLS:llama>
             DESTINATION ${SKBUILD_PLATLIB_DIR}/llama_cpp


### PR DESCRIPTION
When compiling for the HIP SDK version 5.7 on Windows I get the following error.
```
      CMake Error at C:/Users/Engininja2/AppData/Local/Temp/tmptb9uvli3/build/cmake_install.cmake:241 (file):
        file INSTALL cannot find "C:/Program Files/AMD/ROCm/5.7/bin/amdhip64.dll":
        File exists.
```
AMD's CMake files have CMake looking in the SDK for amdhip64.dll but it's included with the gpu driver in C:\Windows\System32
This PR avoids including it and other runtime dlls when compiled for HIP.