### PR TITLE
Add methods to explicitly free model from memory

### DIFF
--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -56,7 +56,10 @@ class _LlamaModel:
         if self.model is None:
             raise ValueError(f"Failed to load model from file: {path_model}")
 
-    def __del__(self):
+    def __del__(self) -> None:
+        self.close()
+
+    def close(self) -> None:
         if self.model is not None and self._llama_free_model is not None:
             self._llama_free_model(self.model)
             self.model = None

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -349,9 +349,11 @@ class Llama(contextlib.AbstractContextManager):
         if not os.path.exists(model_path):
             raise ValueError(f"Model path does not exist: {model_path}")
 
-        self._model = _LlamaModel(
+        self._stack = contextlib.ExitStack()
+
+        self._model = self._stack.enter_context(_LlamaModel(
             path_model=self.model_path, params=self.model_params, verbose=self.verbose
-        )
+        ))
 
         # Override tokenizer
         self.tokenizer_ = tokenizer or LlamaTokenizer(self)
@@ -363,18 +365,18 @@ class Llama(contextlib.AbstractContextManager):
             self.context_params.n_ctx = self._model.n_ctx_train()
             self.context_params.n_batch = self.n_batch
 
-        self._ctx = _LlamaContext(
+        self._ctx = self._stack.enter_context(_LlamaContext(
             model=self._model,
             params=self.context_params,
             verbose=self.verbose,
-        )
+        ))
 
-        self._batch = _LlamaBatch(
+        self._batch = self._stack.enter_context(_LlamaBatch(
             n_tokens=self.n_batch,
             embd=0,
             n_seq_max=self.context_params.n_ctx,
             verbose=self.verbose,
-        )
+        ))
 
         if self.lora_path:
             if self._model.apply_lora_from_file(
@@ -1945,15 +1947,15 @@ class Llama(contextlib.AbstractContextManager):
 
     def close(self) -> None:
         """Explicitly free the model from memory."""
-        self._model.close()
+        self._stack.close()
 
     def __exit__(
         self,
-        __exc_type: Optional[Type[BaseException]],
-        __exc_value: Optional[BaseException],
-        __traceback: Optional[TracebackType]
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType]
     ) -> Optional[bool]:
-        return self.close()
+        return self._stack.__exit__(exc_type, exc_value, traceback)
 
     @staticmethod
     def logits_to_logprobs(

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 import uuid
@@ -10,6 +11,7 @@ import typing
 import fnmatch
 import warnings
 import multiprocessing
+from types import TracebackType
 
 from typing import (
     List,
@@ -21,6 +23,7 @@ from typing import (
     Deque,
     Callable,
     Dict,
+    Type,
 )
 from collections import deque
 from pathlib import Path
@@ -58,7 +61,7 @@ from ._logger import set_verbose
 from ._utils import suppress_stdout_stderr
 
 
-class Llama:
+class Llama(contextlib.AbstractContextManager):
     """High-level Python wrapper for a llama.cpp model."""
 
     __backend_initialized = False
@@ -1939,6 +1942,18 @@ class Llama:
     def pooling_type(self) -> str:
         """Return the pooling type."""
         return self._ctx.pooling_type()
+
+    def close(self) -> None:
+        """Explicitly free the model from memory."""
+        self._model.close()
+
+    def __exit__(
+        self,
+        __exc_type: Optional[Type[BaseException]],
+        __exc_value: Optional[BaseException],
+        __traceback: Optional[TracebackType]
+    ) -> Optional[bool]:
+        return self.close()
 
     @staticmethod
     def logits_to_logprobs(

--- a/llama_cpp/server/model.py
+++ b/llama_cpp/server/model.py
@@ -44,6 +44,8 @@ class LlamaProxy:
             if self._current_model is not None:
                 return self._current_model
 
+        if self._current_model:
+            self._current_model.close()
         self._current_model = None
 
         settings = self._model_settings_dict[model]
@@ -65,6 +67,7 @@ class LlamaProxy:
 
     def free(self):
         if self._current_model:
+            self._current_model.close()
             del self._current_model
 
     @staticmethod


### PR DESCRIPTION
This PR introduces a `close` method to `Llama` and `_LlamaModel`, allowing users to explicitly free the model from RAM/VRAM.

The previous implementation relied on the destructor of `_LlamaModel` to free the model. However, in Python, the timing of destructor calls is unclear: for instance, the `del` statement does not guarantee immediate invocation of the destructor.

This PR offers an explicit method to release the model, which works immediately and enables the user to load another model without encountering memory issues. Here is an example:

```python
from llama_cpp import Llama

llama = Llama(...)
...
llama.close()
```

Additionally, this PR allows the the `Llama` class class to be used as a context manager via the `contextlib.closing` interface. Here is an example:

```python
from contextlib import closing
from llama_cpp import Llama

with closing(Llama(...)) as llama:
    ...
    # the model will be freed here

...
```