### PR TITLE
The beam search and llama_token_get_type related functions have

### DIFF
--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -128,10 +128,6 @@ class _LlamaModel:
         assert self.model is not None
         return llama_cpp.llama_token_get_score(self.model, token)
 
-    def token_get_type(self, token: int) -> int:
-        assert self.model is not None
-        return llama_cpp.llama_token_get_type(self.model, token)
-
     # Special tokens
 
     def token_bos(self) -> int:


### PR DESCRIPTION
recently been removed from llama.cpp and are no longer present in the latest commit (f83351f9a62a6262f1fc3d08f320033089cddfb5) This causes llama-cpp-python import to fail due to missing symbols. This commit removes the stale references from llama-cpp-python.

without these changes, llama_cpp generates the following symbol lookup errors on import:

```
libllama.so: undefined symbol: llama_beam_search
libllama.so: undefined symbol: llama_token_get_type. Did you mean: 'llama_token_get_text'?
```

these deletions eliminate the symbol lookup errors.
