### PR TITLE
Update readme examples to use newer Qwen2 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ You'll need to install the `huggingface-hub` package to use this feature (`pip i
 
 ```python
 llm = Llama.from_pretrained(
-    repo_id="Qwen/Qwen1.5-0.5B-Chat-GGUF",
+    repo_id="Qwen/Qwen2-0.5B-Instruct-GGUF",
     filename="*q8_0.gguf",
     verbose=False
 )
@@ -688,7 +688,7 @@ For possible options, see [llama_cpp/llama_chat_format.py](llama_cpp/llama_chat_
 If you have `huggingface-hub` installed, you can also use the `--hf_model_repo_id` flag to load a model from the Hugging Face Hub.
 
 ```bash
-python3 -m llama_cpp.server --hf_model_repo_id Qwen/Qwen1.5-0.5B-Chat-GGUF --model '*q8_0.gguf'
+python3 -m llama_cpp.server --hf_model_repo_id Qwen/Qwen2-0.5B-Instruct-GGUF --model '*q8_0.gguf'
 ```
 
 ### Web Server Features


### PR DESCRIPTION
Qwen2 generally outperforms Qwen1.5 according to released [benchmarks](https://huggingface.co/Qwen/Qwen2-1.5B-Instruct):

| Datasets | Qwen1.5-0.5B-Chat | Qwen2-0.5B-Instruct |
| --- | --- | --- |
| MMLU | 35.0 | 37.9 |
| HumanEval | 9.1 | 17.1 |
| GSM8K | 11.3 | 40.1 |
| C-Eval | 37.2 | 45.2 |
| IFEval (Prompt Strict-Acc.) | 14.6 | 20.0 |

This model is working fine for me, and I would expect it to generally provide a better experience for users exploring this package. I would expect speed to be nearly identical given the similar sizes of these two models.