### PR TITLE
Support images from local storage for Llava models

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -2742,7 +2742,18 @@ class Llava15ChatHandler:
     @staticmethod
     def _load_image(image_url: str) -> bytes:
         # TODO: Add Pillow support for other image formats beyond (jpg, png)
-        if image_url.startswith("data:"):
+
+        # load image from disk
+        if os.path.isfile(image_url):
+            import io
+            from PIL import Image
+
+            image = Image.open(image_url)
+            with io.BytesIO() as buf:
+                image.save(buf, format="png")
+                image_bytes = buf.getvalue()
+                return image_bytes
+        elif image_url.startswith("data:"):
             import base64
 
             image_bytes = base64.b64decode(image_url.split(",")[1])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "numpy>=1.20.0",
     "diskcache>=5.6.1",
     "jinja2>=2.11.3",
+    "pillow>=9.0.0"
 ]
 requires-python = ">=3.8"
 classifiers = [


### PR DESCRIPTION
Currently, passing of images for vision models (Llava) are limited to online image URLs.

This PR adds support for reading images from local storage using pillow.
Path of the image can be passed in as URL in messages.