### PR TITLE
Actually use split_mode from model settings

### DIFF
--- a/llama_cpp/server/model.py
+++ b/llama_cpp/server/model.py
@@ -223,6 +223,7 @@ class LlamaProxy:
             **kwargs,
             # Model Params
             n_gpu_layers=settings.n_gpu_layers,
+            split_mode=settings.split_mode,
             main_gpu=settings.main_gpu,
             tensor_split=settings.tensor_split,
             vocab_only=settings.vocab_only,


### PR DESCRIPTION
One of the parameters, `split_mode`, was not used when loading. Fix it by passing it to the Llama server.