### PR TITLE
Enable detokenizing special tokens

### DIFF
--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -214,7 +214,7 @@ class _LlamaModel:
         llama_cpp.llama_token_to_piece(self.model, token, buf, 32, 0, special)
         return bytes(buf)
 
-    def detokenize(self, tokens: List[int], special: bool = False) -> bytes:
+    def detokenize(self, tokens: List[int], prev_tokens: Optional[List[int]] = None, special: bool = False) -> bytes:
         assert self.model is not None
         output = b""
         size = 32

--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -214,7 +214,7 @@ class _LlamaModel:
         llama_cpp.llama_token_to_piece(self.model, token, buf, 32, 0, special)
         return bytes(buf)
 
-    def detokenize(self, tokens: List[int], prev_tokens: Optional[List[int]] = None, special: bool = False) -> bytes:
+    def detokenize(self, tokens: List[int], special: bool = False) -> bytes:
         assert self.model is not None
         output = b""
         size = 32

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -578,6 +578,8 @@ class Llama:
 
         Args:
             text: The utf-8 encoded string to tokenize.
+            add_bos: Whether to add a beginning of sequence token.
+            special: Whether to tokenize special tokens.
 
         Raises:
             RuntimeError: If the tokenization failed.
@@ -594,7 +596,8 @@ class Llama:
 
         Args:
             tokens: The list of tokens to detokenize.
-            prev_tokens: The list of previous tokens. Offset mapping will be performed if provided
+            prev_tokens: The list of previous tokens. Offset mapping will be performed if provided.
+            special: Whether to detokenize special tokens.
 
         Returns:
             The detokenized string.

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -588,7 +588,7 @@ class Llama:
         return self.tokenizer_.tokenize(text, add_bos, special)
 
     def detokenize(
-        self, tokens: List[int], prev_tokens: Optional[List[int]] = None
+        self, tokens: List[int], prev_tokens: Optional[List[int]] = None, special: bool = False
     ) -> bytes:
         """Detokenize a list of tokens.
 
@@ -599,7 +599,7 @@ class Llama:
         Returns:
             The detokenized string.
         """
-        return self.tokenizer_.detokenize(tokens, prev_tokens=prev_tokens)
+        return self.tokenizer_.detokenize(tokens, prev_tokens=prev_tokens, special=special)
 
     def set_cache(self, cache: Optional[BaseLlamaCache]):
         """Set the cache.

--- a/llama_cpp/llama_tokenizer.py
+++ b/llama_cpp/llama_tokenizer.py
@@ -19,9 +19,10 @@ class BaseLlamaTokenizer(abc.ABC):
         """Tokenize the text into tokens.
 
         Args:
-            text: The text to tokenize.
+            text: The utf-8 encoded string to tokenize.
             add_bos: Whether to add a beginning of sequence token.
-            special: Whether to tokenize text literally or as special tokens."""
+            special: Whether to tokenize special tokens.
+        """
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -31,8 +32,9 @@ class BaseLlamaTokenizer(abc.ABC):
         """Detokenize the tokens into text.
 
         Args:
-            tokens: The tokens to detokenize.
-            prev_tokens: If tokens is a continuation of a previous sequence, the previous tokens.
+            tokens: The list of tokens to detokenize.
+            prev_tokens: The list of previous tokens. Offset mapping will be performed if provided.
+            special: Whether to detokenize special tokens.
         """
         raise NotImplementedError
 

--- a/llama_cpp/llama_tokenizer.py
+++ b/llama_cpp/llama_tokenizer.py
@@ -26,7 +26,7 @@ class BaseLlamaTokenizer(abc.ABC):
 
     @abc.abstractmethod
     def detokenize(
-        self, tokens: List[int], prev_tokens: Optional[List[int]] = None
+        self, tokens: List[int], prev_tokens: Optional[List[int]] = None, special: bool = True
     ) -> bytes:
         """Detokenize the tokens into text.
 
@@ -47,9 +47,9 @@ class LlamaTokenizer(BaseLlamaTokenizer):
         return self._model.tokenize(text, add_bos=add_bos, special=special)
 
     def detokenize(
-        self, tokens: List[int], prev_tokens: Optional[List[int]] = None
+        self, tokens: List[int], prev_tokens: Optional[List[int]] = None, special: bool = True
     ) -> bytes:
-        return self._model.detokenize(tokens)
+        return self._model.detokenize(tokens, prev_tokens=prev_tokens, special=special)
 
     def encode(
         self, text: str, add_bos: bool = True, special: bool = True

--- a/llama_cpp/llama_tokenizer.py
+++ b/llama_cpp/llama_tokenizer.py
@@ -27,7 +27,7 @@ class BaseLlamaTokenizer(abc.ABC):
 
     @abc.abstractmethod
     def detokenize(
-        self, tokens: List[int], prev_tokens: Optional[List[int]] = None, special: bool = True
+        self, tokens: List[int], prev_tokens: Optional[List[int]] = None, special: bool = False
     ) -> bytes:
         """Detokenize the tokens into text.
 
@@ -49,14 +49,9 @@ class LlamaTokenizer(BaseLlamaTokenizer):
         return self._model.tokenize(text, add_bos=add_bos, special=special)
 
     def detokenize(
-        self, tokens: List[int], prev_tokens: Optional[List[int]] = None, special: bool = True
+        self, tokens: List[int], prev_tokens: Optional[List[int]] = None, special: bool = False
     ) -> bytes:
-        if prev_tokens is not None:
-            text = self._model.detokenize(prev_tokens + tokens, special=special)
-            prev_text = self._model.detokenize(prev_tokens, special=special)
-            return text[len(prev_text) :]
-        else:
-            return self._model.detokenize(tokens, special=special)
+        return self._model.detokenize(tokens, special=special)
 
     def encode(
         self, text: str, add_bos: bool = True, special: bool = True
@@ -85,7 +80,7 @@ class LlamaHFTokenizer(BaseLlamaTokenizer):
         )
 
     def detokenize(
-        self, tokens: List[int], prev_tokens: Optional[List[int]] = None, special: bool = True
+        self, tokens: List[int], prev_tokens: Optional[List[int]] = None, special: bool = False
     ) -> bytes:
         skip_special_tokens = not special 
         if prev_tokens is not None:

--- a/llama_cpp/llama_tokenizer.py
+++ b/llama_cpp/llama_tokenizer.py
@@ -78,18 +78,19 @@ class LlamaHFTokenizer(BaseLlamaTokenizer):
         )
 
     def detokenize(
-        self, tokens: List[int], prev_tokens: Optional[List[int]] = None
+        self, tokens: List[int], prev_tokens: Optional[List[int]] = None, special: bool = True
     ) -> bytes:
+        skip_special_tokens = not special 
         if prev_tokens is not None:
-            text = self.hf_tokenizer.decode(prev_tokens + tokens).encode(
+            text = self.hf_tokenizer.decode(prev_tokens + tokens, skip_special_tokens=skip_special_tokens).encode(
                 "utf-8", errors="ignore"
             )
-            prev_text = self.hf_tokenizer.decode(prev_tokens).encode(
+            prev_text = self.hf_tokenizer.decode(prev_tokens, skip_special_tokens=skip_special_tokens).encode(
                 "utf-8", errors="ignore"
             )
             return text[len(prev_text) :]
         else:
-            return self.hf_tokenizer.decode(tokens).encode("utf-8", errors="ignore")
+            return self.hf_tokenizer.decode(tokens, skip_special_tokens=skip_special_tokens).encode("utf-8", errors="ignore")
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: str) -> "LlamaHFTokenizer":

--- a/llama_cpp/llama_tokenizer.py
+++ b/llama_cpp/llama_tokenizer.py
@@ -49,7 +49,12 @@ class LlamaTokenizer(BaseLlamaTokenizer):
     def detokenize(
         self, tokens: List[int], prev_tokens: Optional[List[int]] = None, special: bool = True
     ) -> bytes:
-        return self._model.detokenize(tokens, prev_tokens=prev_tokens, special=special)
+        if prev_tokens is not None:
+            text = self._model.detokenize(prev_tokens + tokens, special=special)
+            prev_text = self._model.detokenize(prev_tokens, special=special)
+            return text[len(prev_text) :]
+        else:
+            return self._model.detokenize(tokens, special=special)
 
     def encode(
         self, text: str, add_bos: bool = True, special: bool = True


### PR DESCRIPTION
I noticed that it was not possible to detokenize special tokens, such as the EOS token, when using Phi-3(.1). This PR makes sure that the `special` flag can be passed to the `detokenize()` method of both the `LlamaTokenizer` and the `LlamaHFTokenizer`

I also noticed that `prev_tokens` was not being used in the detokenize method of `LlamaTokenizer`, so this PR also adds that functionality based on `LlamaHFTokenizer`