### PR TITLE
Add 'required' literal to ChatCompletionToolChoiceOption

### DIFF
--- a/llama_cpp/llama_types.py
+++ b/llama_cpp/llama_types.py
@@ -275,7 +275,7 @@ class ChatCompletionNamedToolChoice(TypedDict):
 
 
 ChatCompletionToolChoiceOption = Union[
-    Literal["none", "auto"], ChatCompletionNamedToolChoice
+    Literal["none", "auto", "required"], ChatCompletionNamedToolChoice
 ]
 
 


### PR DESCRIPTION
:wave: @abetlen - thanks for this lib!

just adding the 'required' literal to match https://github.com/openai/openai-python/blob/main/src/openai/types/chat/chat_completion_tool_choice_option_param.py#L12
