### PR TITLE
Update chatml-function-calling handler to allow 'required' tool choice

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -3525,7 +3525,7 @@ def chatml_function_calling(
         )
 
     # Case 3: Automatic tool choice
-    assert isinstance(tool_choice, str) and tool_choice == "auto"
+    assert isinstance(tool_choice, str) and tool_choice in ["auto", "required"]
     function_names = " | ".join(
         [f'''"functions.{tool['function']['name']}:"''' for tool in tools]
     )


### PR DESCRIPTION
A follow up to #1597 to allow the 'required' tool choice in the chatml-function-calling handler