### PR TITLE
Fix for broken docker image - llama-cpp-python:latest

### DIFF
--- a/docker/simple/Dockerfile
+++ b/docker/simple/Dockerfile
@@ -35,4 +35,4 @@ ENV PORT=8000
 EXPOSE 8000
 
 # Run the server start script
-CMD ["/bin/sh", "/app/run.sh"]
+CMD ["/bin/sh", "/app/docker/simple/run.sh"]


### PR DESCRIPTION
Currently if you pull the latest image and run, you will face, No such file error due to a filepath change in last commit

`@mashuk999 ➜ /workspaces/llama-cpp-python (main) $ docker run -it ghcr.io/abetlen/llama-cpp-python:latest
Unable to find image 'ghcr.io/abetlen/llama-cpp-python:latest' locally
latest: Pulling from abetlen/llama-cpp-python
f11c1adaa26e: Pull complete 
f2856587ea65: Pull complete 
3633d497474f: Pull complete 
a49add4e8750: Pull complete 
a503d964c760: Pull complete 
3a1a379ae865: Pull complete 
e2df0e42496e: Pull complete 
4f4fb700ef54: Pull complete 
a6bcd4dec1a1: Pull complete 
8bbda24c4a05: Pull complete 
eb190ca62661: Pull complete 
b38e68be4046: Pull complete 
Digest: sha256:fdd7ef0bfbca0a68a918d71c49cb85d5630a418dcfa1484fcb1b854b5f7bd1d7
Status: Downloaded newer image for ghcr.io/abetlen/llama-cpp-python:latest
/bin/sh: 0: cannot open /app/run.sh: No such file
@mashuk999 ➜ /workspaces/llama-cpp-python (main) $ `

This fixes the filepath by reverting to original path to ensure llamacpp server can start