### PR TITLE
Fix : Runtime errors

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -2083,11 +2083,14 @@ class Llama:
 
     def close(self) -> None:
         """Explicitly free the model from memory."""
-        self._stack.close()
+        if hasattr(self,'_stack'):
+            if self._stack is not None:
+                self._stack.close()
 
     def __del__(self) -> None:
-        if self._lora_adapter is not None:
-            llama_cpp.llama_lora_adapter_free(self._lora_adapter)
+        if hasattr(self,'_lora_adapter'):
+            if self._lora_adapter is not None:
+                llama_cpp.llama_lora_adapter_free(self._lora_adapter)
         self.close()
 
     @staticmethod


### PR DESCRIPTION
Fix : Runtime erors. Non-existent variables   _stack and _lora_adapter were being accessed for destruction.

Closes #1631 