### PR TITLE
Fix crash when using grammar

### DIFF
--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -511,7 +511,7 @@ class _LlamaContext:
     def grammar_accept_token(self, grammar: LlamaGrammar, token: int):
         assert self.ctx is not None
         assert grammar.grammar is not None
-        llama_cpp.llama_grammar_accept_token(self.ctx, grammar.grammar, token)
+        llama_cpp.llama_grammar_accept_token(grammar.grammar, self.ctx, token)
 
     def reset_timings(self):
         assert self.ctx is not None


### PR DESCRIPTION
Upstream changed some things w/ how grammar works in https://github.com/ggerganov/llama.cpp/pull/8508 and https://github.com/ggerganov/llama.cpp/pull/8093 - may also want to check if `llama_grammar_init` return value is null, since this is what's done now rather than throwing an error. 

Old argument order for `llama_grammar_accept_token` was:
llama_grammar_accept_token(ctx, grammar, token)

Now this is:
llama_grammar_accept_token(grammar, ctx, token)


Can test with

```python
model = llama_cpp.Llama("bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/Meta-Llama-3.1-8B-Instruct-Q8_0.gguf", n_ctx=4096, n_gpu_layers=-1, offload_kqv=True, n_batch=1024, n_threads=12, n_threads_batch=12, verbose=True)
model.create_chat_completion(
    messages=[
        {
            "role": "system",
            "content": "You are a helpful assistant that outputs in JSON.",
        },
        {"role": "user", "content": "Who won the world series in 2020"},
    ],
    response_format={
        "type": "json_object",
        "schema": {
            "type": "object",
            "properties": {"team_name": {"type": "string"}},
            "required": ["team_name"],
        },
    },
    temperature=0.7,
)
```

Should fix #1623 