### PR TITLE
Enable recursive search of `HFFS.ls`

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -2159,7 +2159,7 @@ class Llama:
 
         files = [
             file["name"] if isinstance(file, dict) else file
-            for file in hffs.ls(repo_id)
+            for file in hffs.ls(repo_id, recursive=True))
         ]
 
         # split each file into repo_id, subfolder, filename


### PR DESCRIPTION
Models that are not located at the top-level of hugging face repos are not found. Thus, this PR enables recursive ls of offs.


Enables now:
```python
Llama.from_pretrained(
             "LiteLLMs/OpenELM-270M-GGUF", filename="*/Q2_K-00001-of-00001.gguf",
             subfolder="Q2_K"
         )   
```

which would otherwise fail with:

```
ValueError: No file found in LiteLLMs/OpenELM-270M-GGUF that match */Q2_K-00001-of-00001.gguf

Available Files:
["Q2_K", "Q3_K", "Q3_K_L", "Q3_K_M", "Q3_K_S", "Q4_0", "Q4_1", "Q4_K", "Q4_K_M", "Q4_K_S", "Q5_0", "Q5_1", "Q5_K", "Q5_K_M", "Q5_K_S", "Q6_K", "Q8_0", ".gitattributes"]
```

