### PR TITLE
fix: only print 'cache saved' in verbose mode

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -1523,7 +1523,8 @@ class Llama:
                 if self.verbose:
                     print("Llama._create_completion: cache save", file=sys.stderr)
                 self.cache[prompt_tokens + completion_tokens] = self.save_state()
-                print("Llama._create_completion: cache saved", file=sys.stderr)
+                if self.verbose:
+                    print("Llama._create_completion: cache saved", file=sys.stderr)
             return
 
         if self.cache:


### PR DESCRIPTION
Before this PR, `Llama._create_completion: cache saved` was printed to stderr even if verbose mode was disabled.

After this PR, that message is only printed to stderr if verbose mode is enabled.