### PR TITLE
Missing dependencies for test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,10 @@ test = [
     "pytest>=7.4.0",
     "httpx>=0.24.1",
     "scipy>=1.10",
+    "fastapi>=0.100.0",
+    "sse-starlette>=1.6.1",
+    "starlette-context>=0.3.6,<0.4",
+    "pydantic-settings>=2.0.1",
 ]
 dev = [
     "black>=23.3.0",


### PR DESCRIPTION
When I ran tests using this command:

```shell-session
pip install -e ".[test]"
python -m pytest
```

I got this error message:

```python
    def test_llama_server():
>       from fastapi.testclient import TestClient
E       ModuleNotFoundError: No module named 'fastapi'

tests/test_llama.py:246: ModuleNotFoundError
```

This PR adds the missing dependencies for the test feature.