### PR TITLE
Remove unnecessary pyproject optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core[pyproject]>=0.9.2"]
+requires = ["scikit-build-core>=0.9.2"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
scikit-build-core made `[pyproject]` and empty optional dependency since 0.9.0