### PR TITLE
fix: chat API logprobs format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ docker:
 	docker build -t llama-cpp-python:latest -f docker/simple/Dockerfile .
 
 run-server:
-	uvicorn --factory llama.server:app --host ${HOST} --port ${PORT}
+	python llama_cpp/server --model ${MODEL}
 
 clean:
 	- cd vendor/llama.cpp && make clean

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -269,13 +269,15 @@ def _convert_text_completion_logprobs_to_chat(
         "content": [
             {
                 "token": token,
+                "bytes": None,
                 "logprob": logprob,
                 "top_logprobs": [
                     {
                         "token": top_token,
                         "logprob": top_logprob,
+                        "bytes": None,
                     }
-                    for (top_token, top_logprob) in top_logprobs
+                    for top_token, top_logprob in top_logprobs.items()
                 ],
             } for (token, logprob, top_logprobs) in zip(logprobs["tokens"], logprobs["token_logprobs"], logprobs["top_logprobs"])
         ],

--- a/llama_cpp/llama_types.py
+++ b/llama_cpp/llama_types.py
@@ -82,10 +82,28 @@ class ChatCompletionFunction(TypedDict):
     parameters: Dict[str, JsonType]  # TODO: make this more specific
 
 
+class ChatCompletionTopLogprobToken(TypedDict):
+    token: str
+    logprob: float
+    bytes: Optional[List[int]]
+
+
+class ChatCompletionLogprobToken(ChatCompletionTopLogprobToken):
+    token: str
+    logprob: float
+    bytes: Optional[List[int]]
+    top_logprobs: List[ChatCompletionTopLogprobToken]
+
+
+class ChatCompletionLogprobs(TypedDict):
+    content: List[ChatCompletionLogprobToken]
+    refusal: List[ChatCompletionLogprobToken]
+
+
 class ChatCompletionResponseChoice(TypedDict):
     index: int
     message: "ChatCompletionResponseMessage"
-    logprobs: Optional[CompletionLogprobs]
+    logprobs: Optional[ChatCompletionLogprobs]
     finish_reason: Optional[str]
 
 
@@ -134,7 +152,7 @@ class ChatCompletionStreamResponseChoice(TypedDict):
         ChatCompletionStreamResponseDelta, ChatCompletionStreamResponseDeltaEmpty
     ]
     finish_reason: Optional[Literal["stop", "length", "tool_calls", "function_call"]]
-    logprobs: NotRequired[Optional[CompletionLogprobs]]
+    logprobs: NotRequired[Optional[ChatCompletionLogprobs]]
 
 
 class CreateChatCompletionStreamResponse(TypedDict):

--- a/llama_cpp/llama_types.py
+++ b/llama_cpp/llama_types.py
@@ -96,8 +96,8 @@ class ChatCompletionLogprobToken(ChatCompletionTopLogprobToken):
 
 
 class ChatCompletionLogprobs(TypedDict):
-    content: List[ChatCompletionLogprobToken]
-    refusal: List[ChatCompletionLogprobToken]
+    content: Optional[List[ChatCompletionLogprobToken]]
+    refusal: Optional[List[ChatCompletionLogprobToken]]
 
 
 class ChatCompletionResponseChoice(TypedDict):


### PR DESCRIPTION
## Summary

The OpenAI compatible server should match the response structure of the OpenAI API for chat completions. Unfortunately there is a discrepancy with the format of logprobs: we return the logprobs format for the completions API, rather than the *chat* completions API.

This PR:
- updates the types to match the OpenAI API
- adds a function `_convert_text_completion_logprobs_to_chat` which is used in the chat completion responses to convert the logprobs to the new API format
- updates the documentation on running the server locally, as I discovered this was outdated when I went to test things out

## Issues fixed

Fixes #1787 