### PR TITLE
Fix: add missing exit_stack.close() to end of /v1/completions endpoint

### DIFF
--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -344,6 +344,7 @@ async def create_completion(
             ping_message_factory=_ping_message_factory,
         )
     else:
+        exit_stack.close()
         return iterator_or_completion
 
 


### PR DESCRIPTION
- /v1/completions endpoint was missing an exit_stack.close() call

This was causing the llama proxy lock to be retained until exit_stack is cleaned up by garbage collector