### PR TITLE
fix: added missing exit_stack.close() to /v1/chat/completions

### DIFF
--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -314,10 +314,14 @@ async def create_completion(
         else:
             kwargs["logits_processor"].extend(_min_tokens_logits_processor)
 
-    iterator_or_completion: Union[
-        llama_cpp.CreateCompletionResponse,
-        Iterator[llama_cpp.CreateCompletionStreamResponse],
-    ] = await run_in_threadpool(llama, **kwargs)
+    try:
+        iterator_or_completion: Union[
+            llama_cpp.CreateCompletionResponse,
+            Iterator[llama_cpp.CreateCompletionStreamResponse],
+        ] = await run_in_threadpool(llama, **kwargs)
+    except Exception as err:
+        exit_stack.close()
+        raise err
 
     if isinstance(iterator_or_completion, Iterator):
         # EAFP: It's easier to ask for forgiveness than permission
@@ -344,6 +348,7 @@ async def create_completion(
             ping_message_factory=_ping_message_factory,
         )
     else:
+        exit_stack.close()
         return iterator_or_completion
 
 

--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -508,9 +508,13 @@ async def create_chat_completion(
         else:
             kwargs["logits_processor"].extend(_min_tokens_logits_processor)
 
-    iterator_or_completion: Union[
-        llama_cpp.ChatCompletion, Iterator[llama_cpp.ChatCompletionChunk]
-    ] = await run_in_threadpool(llama.create_chat_completion, **kwargs)
+    try:
+        iterator_or_completion: Union[
+            llama_cpp.ChatCompletion, Iterator[llama_cpp.ChatCompletionChunk]
+        ] = await run_in_threadpool(llama.create_chat_completion, **kwargs)
+    except Exception as err:
+        exit_stack.close()
+        raise err
 
     if isinstance(iterator_or_completion, Iterator):
         # EAFP: It's easier to ask for forgiveness than permission

--- a/llama_cpp/server/errors.py
+++ b/llama_cpp/server/errors.py
@@ -134,8 +134,6 @@ class RouteErrorHandler(APIRoute):
         ] = None,
     ) -> Tuple[int, ErrorResponse]:
         """Wraps error message in OpenAI style error response"""
-        print(f"Exception: {str(error)}", file=sys.stderr)
-        traceback.print_exc(file=sys.stderr)
         if body is not None and isinstance(
             body,
             (
@@ -148,6 +146,10 @@ class RouteErrorHandler(APIRoute):
                 match = pattern.search(str(error))
                 if match is not None:
                     return callback(body, match)
+
+        # Only print the trace on unexpected exceptions
+        print(f"Exception: {str(error)}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
 
         # Wrap other errors as internal server error
         return 500, ErrorResponse(


### PR DESCRIPTION
`server.create_chat_completion` would not close the exit_stack if an exception happened while calling `llama.create_chat_completion`.

This PR fixes #1759 and is a superset of #1795.