### PR TITLE
fix: additional_files support glob patterns

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -2255,7 +2255,7 @@ class Llama:
         Returns:
             A Llama model."""
         try:
-            from huggingface_hub import hf_hub_download, HfFileSystem
+            from huggingface_hub import hf_hub_download, snapshot_download, HfFileSystem
             from huggingface_hub.utils import validate_repo_id
         except ImportError:
             raise ImportError(
@@ -2320,10 +2320,14 @@ class Llama:
                     )
 
                 if len(matching_additional_files) > 1:
-                    raise ValueError(
-                        f"Multiple files found in {repo_id} matching {additonal_file_name}\n\n"
-                        f"Available Files:\n{json.dumps(files)}"
+                    snapshot_download(
+                        repo_id=repo_id,
+                        allow_patterns=additonal_file_name,
+                        local_dir=local_dir,
+                        local_dir_use_symlinks=local_dir_use_symlinks,
+                        cache_dir=cache_dir,
                     )
+                    continue
 
                 (matching_additional_file,) = matching_additional_files
 


### PR DESCRIPTION
make parameter additional_files  of `from_pretrained` support glob patterns as it declared in the function anotation as below
```
additional_files: A list of filenames or glob patterns to match additional model files in the repo.
```