### PR TITLE
use n_threads param to call _embed_image_bytes fun

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -2707,7 +2707,7 @@ class Llava15ChatHandler:
     def load_image(self, image_url: str) -> bytes:
         return self._load_image(image_url)
 
-    def _embed_image_bytes(self, image_bytes: bytes, n_threads_batch: int = 1):
+    def _embed_image_bytes(self, image_bytes: bytes, n_threads: int = 1):
         if (
             self._last_image_embed is not None
             and self._last_image_hash is not None
@@ -2722,7 +2722,7 @@ class Llava15ChatHandler:
                 self._last_image_hash = None
             embed = self._llava_cpp.llava_image_embed_make_with_bytes(
                 self.clip_ctx,
-                n_threads_batch,
+                n_threads,
                 (ctypes.c_uint8 * len(image_bytes)).from_buffer(
                     bytearray(image_bytes)
                 ),
@@ -2813,7 +2813,7 @@ class Llava15ChatHandler:
                 llama.eval(tokens)
             else:
                 image_bytes = self.load_image(value)
-                embed = self._embed_image_bytes(image_bytes, llama.context_params.n_threads_batch)
+                embed = self._embed_image_bytes(image_bytes, llama.context_params.n_threads)
                 if llama.n_tokens + embed.contents.n_image_pos > llama.n_ctx():
                     raise ValueError(
                         f"Prompt exceeds n_ctx: {llama.n_tokens + embed.contents.n_image_pos} > {llama.n_ctx()}"


### PR DESCRIPTION
Hello, when I run openbmb/MiniCPM-V-2_6-gguf model, I find llama-cpp-python as a server is slower than llama_cpp's example of minicpmv-cli.
I find the diffrerence is llama-cpp-python's **_embed_image_bytes func** is called with param of n_threads_batch. But llama-cpp's example of minicpmv-cli use n_threads (which value is cpu_cores / 2), when call **llava_image_embed_make_with_bytes** func. The param n_threads make image process more efficient and less time-consuming.

For example, on my CPU (56 cores), it takes more than three times the time.

This parameter affects the time consumption function as follows:
```cpp
bool clip_image_batch_encode(clip_ctx * ctx, const int n_threads, const clip_image_f32_batch * imgs, float * vec) {
    ggml_backend_graph_compute(ctx->backend, gf);
......
}
```
Best wishes.