### PR TITLE
Fix: add missing 'seed' attribute to llama_context_params initialization

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -309,6 +309,7 @@ class Llama:
 
         # Context Params
         self.context_params = llama_cpp.llama_context_default_params()
+        self.context_params.seed = seed
         self.context_params.n_ctx = n_ctx
         self.context_params.n_batch = self.n_batch
         self.context_params.n_ubatch = min(self.n_batch, n_ubatch)


### PR DESCRIPTION
Fixes #1769

Add missing `seed` attribute initialization to `context_params` in Llama class. This resolves the AttributeError that occurs when trying to deepcopy the Llama model or use it with Gradio's State component.

Previously `context_params.seed` was not initialized, causing:
`AttributeError: 'llama_context_params' object has no attribute 'seed'`