### PR TITLE
docs: update ROCm install instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- docs: update ROCm install instructions by @agronholm in #1867
 - fix: clear prompt for recurrent / hybrid models when only a partial prefix matches by @avion23 in #2108
 - fix: match Transformers `tojson` in chat template rendering by @CISC in #1486
 - fix: use env var configured multimodal library override paths when loading shared libraries by @navratil-matej in #1782

--- a/README.md
+++ b/README.md
@@ -173,12 +173,12 @@ pip install llama-cpp-python \
 </details>
 
 <details>
-<summary>hipBLAS (ROCm)</summary>
+<summary>HIP (ROCm)</summary>
 
-To install with hipBLAS / ROCm support for AMD cards, set the `GGML_HIPBLAS=on` environment variable before installing:
+To install with HIP / ROCm support for AMD cards, set the `GGML_HIP=on` environment variable before installing:
 
 ```bash
-CMAKE_ARGS="-DGGML_HIPBLAS=on" pip install llama-cpp-python
+CMAKE_ARGS="-DGGML_HIP=on" pip install llama-cpp-python
 ```
 
 </details>


### PR DESCRIPTION
The updated installation instructions allow the utilization of the GPU, as per the [upstream instructions](https://github.com/ggerganov/llama.cpp/blob/master/docs/build.md#hip).