### PR TITLE
fix: replace anyio.Lock with asyncio.Lock to resolve lock handling issues

### DIFF
--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -5,7 +5,7 @@ import json
 import typing
 import contextlib
 
-from anyio import Lock
+from asyncio import Lock
 from functools import partial
 from typing import Iterator, List, Optional, Union, Dict
 


### PR DESCRIPTION
Fixes #1861

Using `llama_cpp.server` with `"stream": true` parameter resulted in `RuntimeError: The current task is not holding this lock` error.
Using `asyncio.Lock()` instead of `anyio.Lock()` fixes this error.