### PR TITLE
Fix error showing time spent in llama perf context print

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -94,6 +94,7 @@ class Llama:
         offload_kqv: bool = True,
         flash_attn: bool = False,
         # Sampling Params
+        no_perf: bool = False,
         last_n_tokens_size: int = 64,
         # LoRA Params
         lora_base: Optional[str] = None,
@@ -173,6 +174,7 @@ class Llama:
             embedding: Embedding mode only.
             offload_kqv: Offload K, Q, V to GPU.
             flash_attn: Use flash attention.
+            no_perf: Measure performance timings.
             last_n_tokens_size: Maximum number of tokens to keep in the last_n_tokens deque.
             lora_base: Optional path to base model, useful if using a quantized base model and you want to apply LoRA to an f16 model.
             lora_path: Path to a LoRA file to apply to the model.
@@ -351,6 +353,7 @@ class Llama:
         if type_v is not None:
             self.context_params.type_v = type_v
         # Sampling Params
+        self.context_params.no_perf = no_perf
         self.last_n_tokens_size = last_n_tokens_size
 
         self.cache: Optional[BaseLlamaCache] = None
@@ -2093,6 +2096,7 @@ class Llama:
             offload_kqv=self.context_params.offload_kqv,
             flash_attn=self.context_params.flash_attn,
             # Sampling Params
+            no_perf=self.context_params.no_perf,
             last_n_tokens_size=self.last_n_tokens_size,
             # LoRA Params
             lora_base=self.lora_base,

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -782,6 +782,7 @@ class llama_context_params(ctypes.Structure):
         embeddings (bool): if true, extract embeddings (together with logits)
         offload_kqv (bool): whether to offload the KQV ops (including the KV cache) to GPU
         flash_attn (bool): whether to use flash attention
+        no_perf (bool): whether to measure performance timings
         abort_callback (ggml_abort_callback): abort callback if it returns true, execution of llama_decode() will be aborted
         abort_callback_data (ctypes.ctypes.c_void_p): data for abort_callback
     """
@@ -812,6 +813,7 @@ class llama_context_params(ctypes.Structure):
         embeddings: bool
         offload_kqv: bool
         flash_attn: bool
+        no_perf: bool
         abort_callback: Callable[[ctypes.c_void_p], bool]
         abort_callback_data: ctypes.c_void_p
 
@@ -841,6 +843,7 @@ class llama_context_params(ctypes.Structure):
         ("embeddings", ctypes.c_bool),
         ("offload_kqv", ctypes.c_bool),
         ("flash_attn", ctypes.c_bool),
+        ("no_perf", ctypes.c_bool),
         ("abort_callback", ggml_abort_callback),
         ("abort_callback_data", ctypes.c_void_p),
     ]


### PR DESCRIPTION
This PR addresses the issue reported here: https://github.com/abetlen/llama-cpp-python/issues/1830 - After the 0.3.0 update, [llama_perf_context_print() ](https://github.com/ggerganov/llama.cpp/blob/3edfa7d3753c29e44b964c0ff424d2ea8d5fdee6/src/llama.cpp#L10049)failed to correctly display inference time, tokens per second, and other related data. 

After some investigation, I found that this change: https://github.com/abetlen/llama-cpp-python/commit/f8fcb3ea3424bcfba3a5437626a994771a02324b, caused this issue due to a commit in the upstream llama.cpp repo: https://github.com/ggerganov/llama.cpp/commit/0abc6a2c25272d5cf01384dda8ee8bfec4ba8745. When designing the `no_perf` parameter, although it defaults to **false**, it is set to **true** in the [llama_context_default_params()](https://github.com/ggerganov/llama.cpp/blob/3edfa7d3753c29e44b964c0ff424d2ea8d5fdee6/src/llama.cpp#L9311) function for external program calls, leading to incorrect calculation of performance metrics when calling [llama_synchronize()](https://github.com/ggerganov/llama.cpp/blob/3edfa7d3753c29e44b964c0ff424d2ea8d5fdee6/src/llama-context.cpp#L660). As a result, llama-cpp-python displays incorrect information when using llama_perf_context_print().

In addition to adding the `no_perf` field in `llama_cpp.py`, we should also set `no_perf` to **false** in `llama.py`. Since llama-cpp-python project always calls `llama_perf_context_print()` during usage, I don't see a reason not to collect this information. Of course, if we want to maintain consistency with llama.cpp's settings, we can add an API to allow users to set the `no_perf` value, providing a way to toggle performance statistics.

