### PR TITLE
fix(types): remove redundant type (typo with repeating lines)

### DIFF
--- a/llama_cpp/llama_types.py
+++ b/llama_cpp/llama_types.py
@@ -255,7 +255,6 @@ ChatCompletionRequestMessage = Union[
     ChatCompletionRequestSystemMessage,
     ChatCompletionRequestUserMessage,
     ChatCompletionRequestAssistantMessage,
-    ChatCompletionRequestUserMessage,
     ChatCompletionRequestToolMessage,
     ChatCompletionRequestFunctionMessage,
 ]


### PR DESCRIPTION
Remove redundant  type hint, which was caused by typo or smth like that.
Those type hints completely equals, so that does not make any sense.