### PR TITLE
Update README.md For llama.cpp HIPBLAS compile instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ pip install llama-cpp-python \
 <details>
 <summary>hipBLAS (ROCm)</summary>
 
-To install with hipBLAS / ROCm support for AMD cards, set the `GGML_HIPBLAS=on` environment variable before installing:
+To install with hipBLAS / ROCm support for AMD cards, set the `GGML_HIP=on` environment variable before installing:
 
 ```bash
-CMAKE_ARGS="-DGGML_HIPBLAS=on" pip install llama-cpp-python
+CMAKE_ARGS="-DGGML_HIP=on" pip install llama-cpp-python
 ```
 
 </details>


### PR DESCRIPTION
[From llama.cpp repo -DGGML_HIP=on is now the required CMAKE flag for HIPBlas/ROCM.](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md#hip)