### PR TITLE
sdist: include .ggml_build_number in tarball

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        fetch-depth: 0
         submodules: "recursive"
 
     - name: Set up Python
@@ -41,6 +42,7 @@ jobs:
 
     - name: Build source distribution
       run: |
+        (cd vendor/llama.cpp && git rev-list --count HEAD) > .ggml_build_number
         python -m build --sdist
 
     - name: Publish distribution to PyPI

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.ggml_build_number
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ wheel.packages = ["llama_cpp"]
 cmake.verbose = true
 cmake.minimum-version = "3.21"
 minimum-version = "0.5.1"
-sdist.include = [".git", "vendor/llama.cpp/*"]
+sdist.include = [".ggml_build_number", "vendor/llama.cpp/*"]
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"


### PR DESCRIPTION
With that, builds using tarball will still have the correct cmake
package version for ggml.

This assumes the file is read by llama.cpp build system, see:
https://github.com/ggml-org/llama.cpp/pull/12509

Fixes #1979
