### PR TITLE
feat: add Jinja2 loop controls to chat templates

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -211,6 +211,7 @@ class Jinja2ChatFormatter(ChatFormatter):
             loader=jinja2.BaseLoader(),
             trim_blocks=True,
             lstrip_blocks=True,
+            extensions=["jinja2.ext.loopcontrols"]
         ).from_string(self.template)
 
     def __call__(

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -223,6 +223,8 @@ class Jinja2ChatFormatter(ChatFormatter):
             loader=jinja2.BaseLoader(),
             trim_blocks=True,
             lstrip_blocks=True,
+            # Keep this aligned with Transformers' chat-template Jinja extensions.
+            # https://github.com/huggingface/transformers/blob/39603d0e5cdb6f00e8d473d7fcbb01032d709181/src/transformers/utils/chat_template_utils.py#L489-L490
             extensions=[
                 Jinja2ChatFormatter.IgnoreGenerationTags,
                 jinja2.ext.loopcontrols,


### PR DESCRIPTION
Hi there -- Cohere's Command models use `break` in their jinja templates. Adding the `jinja2.ext.loopcontrols` extesion to the jinja environment is sufficient to enable support.