### PR TITLE
Improve error message when model file is missing

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -369,15 +369,25 @@ class Llama:
         if not os.path.exists(model_path):
             raise ValueError(f"Model path does not exist: {model_path}")
 
-        self._model = self._stack.enter_context(
-            contextlib.closing(
-                internals.LlamaModel(
-                    path_model=self.model_path,
-                    params=self.model_params,
-                    verbose=self.verbose,
+        try:
+            self._model = self._stack.enter_context(
+                contextlib.closing(
+                    internals.LlamaModel(
+                        path_model=self.model_path,
+                        params=self.model_params,
+                        verbose=self.verbose,
+                    )
                 )
-            )
-        )
+            )   
+        except RuntimeError as e:
+            if "No such file or directory" in str(e):
+                raise FileNotFoundError(
+                    f"Model file not found at '{self.model_path}'. "
+                    "Make sure the .gguf model file exists at the given path."
+                ) from e
+            else:
+                raise
+
 
         # Override tokenizer
         self.tokenizer_ = tokenizer or LlamaTokenizer(self)


### PR DESCRIPTION
### Summary

This PR improves the user experience when the specified ".gguf" model file is missing or the path is incorrect.

### What Changed

- Wrapped the "internals.LlamaModel" call in a `try-except` block.
- Raised a Python "FileNotFoundError" with a clear, helpful message instead of a raw C++ runtime error.

### Why It Matters

The previous behavior showed a confusing stack trace when the model file was not found. This update makes it clear that the issue is a missing or incorrect model path — saving users time and frustration.

### Related Issue

Fixes #1381
