### PR TITLE
Actually create a random seed when using seed = -1 on load

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -304,7 +304,11 @@ class Llama:
         self.n_threads_batch = n_threads_batch or multiprocessing.cpu_count()
 
         # Used by the sampler
-        self._seed = seed or llama_cpp.LLAMA_DEFAULT_SEED
+        if seed == -1:
+            # set a random seed
+            self._seed = random.randint(0, 2 ** 32)
+        else:
+            self._seed = seed or llama_cpp.LLAMA_DEFAULT_SEED
 
         # Context Params
         self.context_params = llama_cpp.llama_context_default_params()


### PR DESCRIPTION
Set a random initial seed if using `-1` as the seed argument, like stated in the API reference here:

> seed ([int](https://docs.python.org/3/library/functions.html#int), default: [LLAMA_DEFAULT_SEED](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#llama_cpp.llama_cpp.LLAMA_DEFAULT_SEED) ) –
> 
> RNG seed, -1 for random

At the moment there is no random seed created, so the first reply of the model when not using a fixed seed, will always be the same, as will be the chain of consecutive replies.

Fixes issue: https://github.com/abetlen/llama-cpp-python/issues/1809