### PR TITLE
fix: rename op_offloat to op_offload in llama.py

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -92,7 +92,7 @@ class Llama:
         embedding: bool = False,
         offload_kqv: bool = True,
         flash_attn: bool = False,
-        op_offloat: Optional[bool] = None,
+        op_offload: Optional[bool] = None,
         swa_full: Optional[bool] = None,
         # Sampling Params
         no_perf: bool = False,
@@ -174,7 +174,7 @@ class Llama:
             embedding: Embedding mode only.
             offload_kqv: Offload K, Q, V to GPU.
             flash_attn: Use flash attention.
-            op_offloat: offload host tensor operations to device
+            op_offload: offload host tensor operations to device
             swa_full: use full-size SWA cache (https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
             no_perf: Measure performance timings.
             last_n_tokens_size: Maximum number of tokens to keep in the last_n_tokens deque.
@@ -343,8 +343,8 @@ class Llama:
         self.context_params.offload_kqv = offload_kqv
         self.context_params.flash_attn = flash_attn
 
-        if op_offloat is not None:
-            self.context_params.op_offloat = op_offloat
+        if op_offload is not None:
+            self.context_params.op_offload = op_offload
 
         if swa_full is not None:
             self.context_params.swa_full = swa_full
@@ -2097,7 +2097,7 @@ class Llama:
             embedding=self.context_params.embeddings,
             offload_kqv=self.context_params.offload_kqv,
             flash_attn=self.context_params.flash_attn,
-            op_offloat=self.context_params.op_offloat,
+            op_offload=self.context_params.op_offload,
             swa_full=self.context_params.swa_full,
             # Sampling Params
             no_perf=self.context_params.no_perf,


### PR DESCRIPTION
Fix typo in variable name: replace `op_offloat` with `op_offload` in llama.py (v0.3.14), that caused `AttributeError` during model copying

Steps to Reproduce:
```python
# pip install llama_cpp_python 
from copy import copy, deepcopy
from llama_cpp import Llama

model = Llama.from_pretrained(
    repo_id='bartowski/google_gemma-3-1b-it-GGUF',
    filename='google_gemma-3-1b-it-Q8_0.gguf',
    verbose=False,
)
deepcopy(model)

---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
[/tmp/ipython-input-119572725.py](https://localhost:8080/#) in <cell line: 0>()
      8     verbose=False,
      9 )
---> 10 deepcopy(model)

1 frames
[/usr/lib/python3.11/copy.py](https://localhost:8080/#) in deepcopy(x, memo, _nil)
    159                     reductor = getattr(x, "__reduce_ex__", None)
    160                     if reductor is not None:
--> 161                         rv = reductor(4)
    162                     else:
    163                         reductor = getattr(x, "__reduce__", None)

[/usr/local/lib/python3.11/dist-packages/llama_cpp/llama.py](https://localhost:8080/#) in __getstate__(self)
   2098             offload_kqv=self.context_params.offload_kqv,
   2099             flash_attn=self.context_params.flash_attn,
-> 2100             op_offloat=self.context_params.op_offloat,
   2101             swa_full=self.context_params.swa_full,
   2102             # Sampling Params

AttributeError: 'llama_context_params' object has no attribute 'op_offloat'
```

Impact: breaks Gradio integration
```python
# pip install gradio 
import gradio as gr
model_state = gr.State({'model': model})
# AttributeError: 'llama_context_params' object has no attribute 'op_offloat'
```