### PR TITLE
Implement GenerationTagIgnore Jinja2 extension

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -194,7 +194,7 @@ class ChatFormatter(Protocol):
 class GenerationTagIgnore(Extension):
     """Ignores the generation and endgeneration tags in Jinja templates."""
 
-    tags = {"generation"}
+    tags = {"generation", "endgeneration"}
 
     def parse(self, parser):
         parser.stream.skip(1)

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -24,6 +24,7 @@ from typing import (
 )
 
 import jinja2
+from jinja2.ext import Extension
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 
 import numpy as np
@@ -190,6 +191,14 @@ class ChatFormatter(Protocol):
         **kwargs: Any,
     ) -> ChatFormatterResponse: ...
 
+class GenerationTagIgnore(Extension):
+    """Ignores the generation and endgeneration tags in Jinja templates."""
+
+    tags = {"generation"}
+
+    def parse(self, parser):
+        parser.stream.skip(1)
+        return nodes.Const("")
 
 class Jinja2ChatFormatter(ChatFormatter):
     def __init__(
@@ -213,6 +222,7 @@ class Jinja2ChatFormatter(ChatFormatter):
             loader=jinja2.BaseLoader(),
             trim_blocks=True,
             lstrip_blocks=True,
+            extensions=[GenerationTagIgnore]
         ).from_string(self.template)
 
     @staticmethod


### PR DESCRIPTION
```
jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'generation'. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.
```

llama-cpp-python failed to load SmoLLM3 because its chat template had `{% generation %}` and `{% endgeneration %}` tags, so I copied the solution from [here](https://github.com/axolotl-ai-cloud/axolotl/pull/2787).