### PR TITLE
Include x64 directory for CUDA DLLs on Windows

### DIFF
--- a/llama_cpp/_ctypes_extensions.py
+++ b/llama_cpp/_ctypes_extensions.py
@@ -54,6 +54,7 @@ def load_shared_library(lib_base_name: str, base_path: pathlib.Path):
         os.add_dll_directory(str(base_path))
         if "CUDA_PATH" in os.environ:
             os.add_dll_directory(os.path.join(os.environ["CUDA_PATH"], "bin"))
+            os.add_dll_directory(os.path.join(os.environ["CUDA_PATH"], "bin", "x64"))
             os.add_dll_directory(os.path.join(os.environ["CUDA_PATH"], "lib"))
         if "HIP_PATH" in os.environ:
             os.add_dll_directory(os.path.join(os.environ["HIP_PATH"], "bin"))


### PR DESCRIPTION
I needed to add this DLL for the library to work on my system (possibly to do with a new cuda toolkit version, unclear). 

Possibly related to https://github.com/abetlen/llama-cpp-python/issues/2070.

If anyone else encounters this, you can work around by adding it before importing:

```
import os
if "CUDA_PATH" in os.environ:
    os.add_dll_directory(os.path.join(os.environ["CUDA_PATH"], "bin", "x64"))
import llama_cpp
```