### PR TITLE
chore: update typing-extensions dependency and set github actions setup-python to v6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.9"
       - name: Install huggingface-hub
@@ -41,7 +41,7 @@ jobs:
           submodules: "recursive"
           
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -72,7 +72,7 @@ jobs:
           submodules: "recursive"
           
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -106,7 +106,7 @@ jobs:
           submodules: "recursive"
           
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -144,7 +144,7 @@ jobs:
           submodules: "recursive"
           
       - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.9"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     { name = "Andrei Betlen", email = "abetlen@gmail.com" },
 ]
 dependencies = [
-    "typing-extensions>=4.5.0",
+    "typing-extensions>=4.15.0",
     "numpy>=1.20.0",
     "diskcache>=5.6.1",
     "jinja2>=2.11.3",


### PR DESCRIPTION
PR changes:
1.  dependencies (`pyproject.toml`): updated the min required version for `typing-extensions` to `4.15.0` .
2.  CI Workflow (`.github/workflows/test.yaml`):
    * upgraded the `actions/setup-python` action from `@v5` to the latest stable version, `@v6`.
    * ensured python `3.12` is explicitly included in the test matrix for full coverage across all OS.