### PR TITLE
Fix Errors in GBNF string constants

### DIFF
--- a/llama_cpp/llama_grammar.py
+++ b/llama_cpp/llama_grammar.py
@@ -104,31 +104,19 @@ ws ::= ([ \t\n]+)
 """
 
 CHESS_GBNF = r"""
-root   ::= object
-value  ::= object | array | string | number | ("true" | "false" | "null") ws
+# Specifies chess moves as a list in algebraic notation, using PGN conventions
 
-object ::=
-  "{" ws (
-            string ":" ws value
-    ("," ws string ":" ws value)*
-  )? "}" ws
+# Force first move to "1. ", then any 1-2 digit number after, relying on model to follow the pattern
+root    ::= "1. " move " " move "\n" ([1-9] [0-9]? ". " move " " move "\n")+
+move    ::= (pawn | nonpawn | castle) [+#]?
 
-array  ::=
-  "[" ws (
-            value
-    ("," ws value)*
-  )? "]" ws
+# piece type, optional file/rank, optional capture, dest file & rank
+nonpawn ::= [NBKQR] [a-h]? [1-8]? "x"? [a-h] [1-8]
 
-string ::=
-  "\"" (
-    [^"\\] |
-    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
-  )* "\"" ws
+# optional file & capture, dest file & rank, optional promotion
+pawn    ::= ([a-h] "x")? [a-h] [1-8] ("=" [NBKQR])?
 
-number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-
-# Optional space: by convention, applied in this grammar after literal chars when allowed
-ws ::= ([ \t\n] ws)?
+castle  ::= "O-O" "-O"?
 """
 
 JAPANESE_GBNF = r"""


### PR DESCRIPTION
JAPANESE_GBNF and CHESS_GBNF are both copies of the `json.gbnf` from the llama.cpp repo. PR replaces this string with the proper `japanese.gbnf` and `chess.gbnf` examples from the repo

There is a significant error in the scientific notation portion of the JSON_GBNF string:
`([eE] [-+]? [0-9] [1-9]{0,15})`
This statement forbids trailing zeros, making `e+10`, `e+100` etc impossible to generate. PR swaps the last two character groups

SPACE_RULE is declared twice, PR removes duplicate 