### PR TITLE
fix: correct typo 'seperated' to 'separated'

### DIFF
--- a/llama_cpp/server/settings.py
+++ b/llama_cpp/server/settings.py
@@ -60,7 +60,7 @@ class ModelSettings(BaseSettings):
     )
     rpc_servers: Optional[str] = Field(
         default=None,
-        description="comma seperated list of rpc servers for offloading",
+        description="comma separated list of rpc servers for offloading",
     )
     # Context Params
     seed: int = Field(


### PR DESCRIPTION
Fixes a typo in the settings description: 'seperated' → 'separated'.