### PR TITLE
fix: correct typos 'seperated' and 'seperator' to 'separated' and 'separator'

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -3171,7 +3171,7 @@ class Llava15ChatHandler:
 
 class ObsidianChatHandler(Llava15ChatHandler):
     # Prompt Format
-    # The model followed ChatML format. However, with ### as the seperator
+    # The model followed ChatML format. However, with ### as the separator
 
     # <|im_start|>user
     # What is this sign about?\n<image>

--- a/llama_cpp/server/settings.py
+++ b/llama_cpp/server/settings.py
@@ -60,7 +60,7 @@ class ModelSettings(BaseSettings):
     )
     rpc_servers: Optional[str] = Field(
         default=None,
-        description="comma seperated list of rpc servers for offloading",
+        description="comma separated list of rpc servers for offloading",
     )
     # Context Params
     seed: int = Field(


### PR DESCRIPTION
Fixes two simple typos:
- 'seperated' → 'separated' in settings.py (description string)
- 'seperator' → 'separator' in llama_chat_format.py (comment)