### PR TITLE
ci: refactor cpu wheel build workflow

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -94,6 +94,15 @@ jobs:
           submodules: "recursive"
 
       - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.9"
+
+      - name: Install dependencies
+        env:
+          RUST_LOG: trace
+        run: |
+          uv venv
+          uv pip install -e .[all] --verbose
 
       - name: Build source distribution
         run: |

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -11,56 +11,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-14, macos-15]
+        os: [ubuntu-22.04, windows-2022, macos-15]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: "recursive"
 
-      # Used to host cibuildwheel
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
-
-      - name: Install dependencies (Linux/MacOS)
-        if: runner.os != 'Windows'
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install uv
-          RUST_LOG=trace python -m uv pip install -e .[all] --verbose
-        shell: bash
-
-      - name: Install dependencies (Windows)
-        if: runner.os == 'Windows'
-        env:
-          RUST_LOG: trace        
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install uv
-          python -m uv pip install -e .[all] --verbose
-        shell: cmd
-
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
-        env:
-          # Keep repair disabled by default for non-Linux platforms in this job.
-          CIBW_REPAIR_WHEEL_COMMAND: ""
-          # Linux needs auditwheel repair so manylinux and musllinux wheels are
-          # published with distinct platform tags instead of generic linux tags.
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel}"
-          # Skip cibuildwheel's default i686 sidecar and keep Linux release
-          # wheels on a portable x86_64 CPU baseline.
-          CIBW_ARCHS_LINUX: "auto64"
-          CIBW_ENVIRONMENT_LINUX: CMAKE_ARGS="-DGGML_NATIVE=off"
-          # Keep macOS release wheels on a portable CPU baseline instead of
-          # inheriting the hosted runner's native flags.
-          CIBW_ENVIRONMENT_MACOS: CMAKE_ARGS="-DGGML_NATIVE=off"
+        uses: pypa/cibuildwheel@v3.4.0
         with:
           package-dir: .
           output-dir: wheelhouse
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
@@ -69,25 +33,17 @@ jobs:
     name: Build arm64 wheels
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: "recursive"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
-        env:
-          CIBW_SKIP: "*musllinux* pp*"
-          CIBW_REPAIR_WHEEL_COMMAND: ""
-          CIBW_ARCHS: "aarch64"
-          # Keep native arm64 builds on a portable CPU baseline instead of
-          # tuning wheels to the hosted runner.
-          CIBW_ENVIRONMENT: CMAKE_ARGS="-DGGML_NATIVE=off"
-          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-*"
+        uses: pypa/cibuildwheel@v3.4.0
         with:
           output-dir: wheelhouse
 
       - name: Upload wheels as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels_arm64
           path: ./wheelhouse/*.whl
@@ -99,50 +55,33 @@ jobs:
       fail-fast: false
       matrix:
         shard:
-          - name: cp310
-            build: "cp310-*"
-            artifact: wheels_riscv64_cp310
-          - name: cp311
-            build: "cp311-*"
-            artifact: wheels_riscv64_cp311
-          - name: cp312
-            build: "cp312-*"
-            artifact: wheels_riscv64_cp312
-          - name: cp313
-            build: "cp313-*"
-            artifact: wheels_riscv64_cp313
-          - name: cp314
-            build: "cp314-*"
-            artifact: wheels_riscv64_cp314
+          - name: manylinux
+            build: "*manylinux*"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: "recursive"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/riscv64
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1.2
+        uses: pypa/cibuildwheel@v3.4.0
         env:
-          CIBW_SKIP: "*musllinux* pp*"
-          CIBW_REPAIR_WHEEL_COMMAND: ""
           CIBW_ARCHS: "riscv64"
           # Build riscv64 wheels against a conservative baseline instead of
           # enabling RVV-related extensions from the build container.
           CIBW_ENVIRONMENT: CMAKE_ARGS="-DGGML_NATIVE=off -DGGML_RVV=off -DGGML_RV_ZFH=off -DGGML_RV_ZVFH=off -DGGML_RV_ZICBOP=off -DGGML_RV_ZIHINTPAUSE=off"
-          # Split the emulated riscv64 build into one Python version per job
-          # to minimize wall-clock time without changing the release artifacts.
           CIBW_BUILD: ${{ matrix.shard.build }}
         with:
           output-dir: wheelhouse
 
       - name: Upload wheels as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.shard.artifact }}
+          name: wheels_riscv64_${{ matrix.shard.name }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -150,39 +89,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: "recursive"
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
-
-      - name: Install dependencies (Linux/MacOS)
-        if: runner.os != 'Windows'
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install uv
-          RUST_LOG=trace python -m uv pip install -e .[all] --verbose
-          python -m uv pip install build
-        shell: bash
-
-      - name: Install dependencies (Windows)
-        if: runner.os == 'Windows'
-        env:
-          RUST_LOG: trace        
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install uv
-          python -m uv pip install -e .[all] --verbose
-          python -m uv pip install build
-        shell: cmd
+      - uses: astral-sh/setup-uv@v7
 
       - name: Build source distribution
         run: |
-          python -m build --sdist
+          uv build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: ./dist/*.tar.gz
@@ -194,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           merge-multiple: true
           path: dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,10 +107,12 @@ test-skip = "*_riscv64"  # riscv64 cannot install test packages (e.g. numpy, sci
 
 [tool.cibuildwheel.linux]
 before-build = "command -v dnf && dnf install -y openssl-devel || (command -v apk && apk add --no-cache openssl-dev) || true"
-repair-wheel-command = "auditwheel repair --exclude 'libcu*' -w {dest_dir} {wheel}"  # don't bundle CUDA libraries
 
 [tool.cibuildwheel.linux.environment]
 CMAKE_ARGS = "-DGGML_NATIVE=OFF"
 
 [tool.cibuildwheel.macos.environment]
 CMAKE_ARGS = "-DGGML_NATIVE=OFF"
+
+[tool.cibuildwheel.windows]
+repair-wheel-command = "pipx run delvewheel repair --analyze-existing --ignore-existing -w {dest_dir} {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core[wheels]>=0.12.2"]
+requires = ["scikit-build-core>=0.12.2"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core[pyproject]>=0.9.2"]
+requires = ["scikit-build-core[wheels]>=0.12.2"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -92,3 +92,25 @@ ignore = ["E712"]
 
 [tool.pytest.ini_options]
 testpaths = "tests"
+
+[tool.cibuildwheel]
+archs = ["auto64"]
+# llama.cpp requires glibc 2.31+. manylinux_2_34 is the oldest manylinux image with glibc 2.31.
+# see all manylinux images here: https://github.com/pypa/manylinux
+manylinux-x86_64-image = "manylinux_2_34"
+manylinux-aarch64-image = "manylinux_2_34"
+skip = "*musllinux*"  # Segmentation fault occurs on musllinux python 3.10+
+test-sources = ["tests", "vendor"]
+test-command = "pytest -v ./tests"
+test-extras = ["test"]
+test-skip = "*_riscv64"  # riscv64 cannot install test packages (e.g. numpy, scipy, pydantic-core, hf-xet, etc.)
+
+[tool.cibuildwheel.linux]
+before-build = "command -v dnf && dnf install -y openssl-devel || (command -v apk && apk add --no-cache openssl-dev) || true"
+repair-wheel-command = "auditwheel repair --exclude 'libcu*' -w {dest_dir} {wheel}"  # don't bundle CUDA libraries
+
+[tool.cibuildwheel.linux.environment]
+CMAKE_ARGS = "-DGGML_NATIVE=OFF"
+
+[tool.cibuildwheel.macos.environment]
+CMAKE_ARGS = "-DGGML_NATIVE=OFF"


### PR DESCRIPTION
fixes #2163

Builds widely reusable wheels.

In fact, since llama-cpp-python uses ctypes, there is no need to specify a Python ABI. Therefore, tags like `py3-none-manylinux_2_34_x86_64.whl` can be used.

Please check the build success log at this link:
https://github.com/Bing-su/llama-cpp-python/actions/runs/23591453286
