### PR TITLE
fix: avoid cleanup errors for partially initialized LlamaModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix: avoid cleanup errors for partially initialized `LlamaModel` objects by @usernames122 in #2173
 - fix: suppress stdout and stderr in Jupyter notebooks by @Anai-Guo in #2181
 - feat: enable arm64 musl builds by @acon96 in #2221
 - feat: Update llama.cpp to ggml-org/llama.cpp@d749821db

--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -76,7 +76,7 @@ class LlamaModel:
         self._exit_stack.callback(free_model)
 
     def close(self):
-        if self.sampler is not None:
+        if hasattr(self, "sampler") and self.sampler is not None:
             # NOTE: Must remove custom samplers before free or llama.cpp will try to free them
             for i, _ in reversed(self.custom_samplers):
                 llama_cpp.llama_sampler_chain_remove(self.sampler, i)

--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -44,6 +44,9 @@ class LlamaModel:
         self.params = params
         self.verbose = verbose
         self._exit_stack = ExitStack()
+        # LlamaModel does not use samplers, but close() can run after partial init.
+        self.sampler = None
+        self.custom_samplers = []
 
         model = None
 
@@ -65,7 +68,6 @@ class LlamaModel:
 
         self.model = model
         self.vocab = vocab
-        self.sampler = None  # LlamaModel doesn't use samplers, but some cleanup code expects this attribute
 
         def free_model():
             if self.model is None:
@@ -76,7 +78,7 @@ class LlamaModel:
         self._exit_stack.callback(free_model)
 
     def close(self):
-        if hasattr(self, "sampler") and self.sampler is not None:
+        if self.sampler is not None:
             # NOTE: Must remove custom samplers before free or llama.cpp will try to free them
             for i, _ in reversed(self.custom_samplers):
                 llama_cpp.llama_sampler_chain_remove(self.sampler, i)


### PR DESCRIPTION
This solves a bug I uncovered, that causes an AttributeError if constantly re-initializing a model in a loop and Python garbage collects it, such as testing the highest GPU layer count you can go before CUDA OOMs.
Specifically, it solves:
```
    if self.sampler is not None:
       ^^^^^^^^^^^^
AttributeError: 'LlamaModel' object has no attribute 'sampler'
```

Fixes #2104