### PR TITLE
build: disable soname to reduce binary size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,11 @@ function(llama_cpp_python_install_target target)
                 INSTALL_RPATH "$ORIGIN"
                 BUILD_WITH_INSTALL_RPATH TRUE
             )
+        set_target_properties(${target} PROPERTIES
+            NO_SONAME TRUE
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+            LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
         endif()
     endif()
 endfunction()


### PR DESCRIPTION
Disable soname to reduce binary size.

As explained in [pep-778](https://peps.python.org/pep-0778/), wheel files currently do not handle symbolic links (it replaces the symbolic link with the original file). This causes the llama-cpp-python wheel file to become larger than the original.

By setting the NO_SONAME flag to prevent the creation of symbolic links, it resolves this issue.

<img width="994" height="793" alt="image" src="https://github.com/user-attachments/assets/212e6689-5bfd-4aad-9176-ebb23b9356f6" />

https://github.com/Bing-su/llama-cpp-python/actions/runs/24200306300


Please also check the built files.

[wheels-ubuntu-22.04.zip](https://github.com/user-attachments/files/26609108/wheels-ubuntu-22.04.zip)
[wheels-windows-2022.zip](https://github.com/user-attachments/files/26609106/wheels-windows-2022.zip)

+ It looks like macos require some different configuration. However, I don't have a Apple machine to test it on...
[wheels-macos-15.zip](https://github.com/user-attachments/files/26609395/wheels-macos-15.zip)
