### PR TITLE
fix: improve error message when LlamaModel fails to load

### DIFF
--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -56,7 +56,19 @@ class LlamaModel:
             )
 
         if model is None:
-            raise ValueError(f"Failed to load model from file: {path_model}")
+            try:
+                size_hint = f" (file size: {os.path.getsize(path_model) / (1024**3):.1f} GB)"
+            except OSError:
+                size_hint = ""
+            raise ValueError(
+                f"Failed to load model from file: {path_model}{size_hint}.
+"
+                "Common causes: insufficient RAM or VRAM for the model size, "
+                "unsupported quantization format, or corrupt file.
+"
+                "Tip: set verbose=True to see the full llama.cpp log, "
+                "or use n_gpu_layers=-1 to offload layers to GPU."
+            )
 
         vocab = llama_cpp.llama_model_get_vocab(model)
 


### PR DESCRIPTION
## Summary

Fixes #2145

When `llama_model_load_from_file` returns `None`, the previous error was:
```
ValueError: Failed to load model from file: /path/to/model.gguf
```

With `verbose=False` (the default), the llama.cpp log is suppressed, so users have no way to know why loading failed. This is particularly confusing for large BF16 models where the silent failure is typically OOM.

## Changes

The error message now includes:
1. **File size in GB** — makes OOM the obvious first suspect
2. **Common causes** — RAM/VRAM, unsupported format, corrupt file
3. **Actionable tips** — `verbose=True` to see the llama.cpp log, `n_gpu_layers=-1` for GPU offloading

### Before
```
ValueError: Failed to load model from file: /root/.cache/.../Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive-BF16.gguf
```

### After
```
ValueError: Failed to load model from file: /root/.cache/.../model.gguf (file size: 67.5 GB).
Common causes: insufficient RAM or VRAM for the model size, unsupported quantization format, or corrupt file.
Tip: set verbose=True to see the full llama.cpp log, or use n_gpu_layers=-1 to offload layers to GPU.
```