### PR TITLE
fix(ci): skip unsupported Windows CUDA versions

### DIFF
--- a/.github/workflows/build-wheels-cuda.yaml
+++ b/.github/workflows/build-wheels-cuda.yaml
@@ -26,6 +26,11 @@ jobs:
               'pyver' = @("3.9")
               'cuda' = @("12.1.1", "12.2.2", "12.3.2", "12.4.1", "12.5.1")
               'releasetag' = @("basic")
+              'exclude' = @(
+                @{ 'os' = 'windows-2022'; 'cuda' = '12.1.1' },
+                @{ 'os' = 'windows-2022'; 'cuda' = '12.2.2' },
+                @{ 'os' = 'windows-2022'; 'cuda' = '12.3.2' }
+              )
           }
 
           $matrixOut = ConvertTo-Json $matrix -Compress


### PR DESCRIPTION
Avoid Windows CUDA 12.1-12.3 wheel builds on the current hosted MSVC toolset. The hosted MSVC STL now requires CUDA 12.4 or newer, while Linux still builds the full CUDA 12.1-12.5 matrix.