### PR TITLE
fix(_internals): use n_tokens0 offset when enabling last-token logits in add_sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix: Correct batched embedding outputs for multi-sequence `embed()` calls by @Anai-Guo in #2205
+
 ## [0.3.22]
 
 - feat: Update llama.cpp to ggerganov/llama.cpp@63d93d173

--- a/llama_cpp/_internals.py
+++ b/llama_cpp/_internals.py
@@ -522,7 +522,7 @@ class LlamaBatch:
             self.batch.seq_id[j][0] = seq_id
             self.batch.n_seq_id[j] = 1
             self.batch.logits[j] = logits_all
-        self.batch.logits[n_tokens - 1] = True
+        self.batch.logits[n_tokens0 + n_tokens - 1] = True
 
 
 class LlamaTokenDataArray:

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -247,3 +247,18 @@ def test_real_llama_embeddings(llama_cpp_embedding_model_path):
     )
     embedding = model.embed("Hello World")
     assert len(embedding) > 0
+
+    prompts = ["Hello World", "A different prompt"]
+    individual_embeddings = [model.embed(prompt) for prompt in prompts]
+    batched_embeddings = model.embed(prompts)
+
+    assert len(batched_embeddings) == len(prompts)
+    for individual, batched in zip(individual_embeddings, batched_embeddings):
+        np.testing.assert_allclose(batched, individual, rtol=1e-4, atol=1e-4)
+
+    repeated_embeddings = model.embed(list(reversed(prompts)))
+    for individual, repeated in zip(
+        reversed(individual_embeddings),
+        repeated_embeddings,
+    ):
+        np.testing.assert_allclose(repeated, individual, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
## Problem

Fixes #2199.

`llm.embed(["test", "test"])` produces wrong results (or fails downstream) for sequence indices ≥ 1, while `[llm.embed(x) for x in ["test", "test"]]` works.

## Root cause

In `llama_cpp/_internals.py` `LlamaBatch.add_sequence`:

```python
def add_sequence(self, batch: Sequence[int], seq_id: int, logits_all: bool):
    n_tokens = len(batch)
    n_tokens0 = self.batch.n_tokens   # offset of THIS sequence inside the running batch
    self.batch.n_tokens += n_tokens
    for i in range(n_tokens):
        j = n_tokens0 + i             # correctly offsets every per-token write
        self.batch.token[j] = batch[i]
        ...
        self.batch.logits[j] = logits_all
    self.batch.logits[n_tokens - 1] = True   # <-- BUG: missing n_tokens0
```

Every per-token write inside the loop correctly uses the offset `j = n_tokens0 + i`, but the trailing "force-enable last-token logits" line uses the *local* `n_tokens - 1` instead of `n_tokens0 + n_tokens - 1`.

Effect with `embed(["test", "test"])` (each tokenized to 3 tokens, no pooling):

| call | n_tokens0 | last-token index of THIS seq | what the buggy line writes |
|---|---|---|---|
| 1st (seq_id=0) | 0 | 2 | `logits[2] = True` ✓ |
| 2nd (seq_id=1) | 3 | 5 | `logits[2] = True` ✗ — already set, real last token (index 5) is left at `logits_all` (False for pooled embeddings) |

For the second sequence, the last token's `logits` flag is never enabled, so `llama_get_embeddings_seq(ctx, 1)` returns garbage / unset data depending on the pooling type. The first sequence's embedding looks fine, which is exactly the asymmetric "first works, batched fails" behavior reported in the issue.

It also overlaps with seq 0's last-token flag, so even when both flags happen to coincide for trivial inputs, any non-trivial batch where sequence sizes differ exposes the bug immediately.

## Fix

Use the same offset `n_tokens0` that the per-token writes already use:

```python
self.batch.logits[n_tokens0 + n_tokens - 1] = True
```

This is a one-line change in `LlamaBatch.add_sequence`. The sibling method `LlamaBatch.set_batch` is unaffected because it always starts from index 0 (`self.batch.n_tokens = n_tokens`, not `+=`).

## Verification

After the fix, the failing reproduction from the issue:

```python
llm = Llama(model_path="all-MiniLM-L6-v2-Q8_0.gguf", embedding=True)
llm.embed(["test", "test"])
```

returns two embeddings whose values match the per-string call:

```python
[llm.embed(x) for x in ["test", "test"]]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
