### PR TITLE
fix(embedding): set kv_unified=True when embedding=True to enable batch processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,5 +179,3 @@ cython_debug/
 
 # downloaded model .bin files
 docker/open_llama/*.bin
-test_model.gguf
-.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,5 @@ cython_debug/
 
 # downloaded model .bin files
 docker/open_llama/*.bin
+test_model.gguf
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix: Enable unified KV cache for embedding contexts to preserve full per-sequence context in batch embedding calls by @SanjanaB123 in #2217
+
 ## [0.3.23]
 
 - feat: Update llama.cpp to ggerganov/llama.cpp@7d442abf

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -402,7 +402,7 @@ class Llama:
                 self.n_batch,
                 llama_cpp.llama_max_parallel_sequences(),
             )
-
+            self.context_params.kv_unified = True
         self._ctx = self._stack.enter_context(
             contextlib.closing(
                 internals.LlamaContext(


### PR DESCRIPTION
Fixes #2216

## Problem
When using `embedding=True`, `n_seq_max` is set to 256 but `kv_unified` 
remains `False` (the default). This causes `n_ctx_seq` to be computed 
as `n_ctx / n_seq_max = 256` tokens per sequence, making batch 
embeddings essentially unusable for inputs longer than 256 tokens.

## Fix
Set `self.context_params.kv_unified = True` inside the `if embedding:` 
block, which allows each sequence to use the full context window 
instead of `n_ctx / n_seq_max`.

## Testing
Verified that both single and batch embeddings work correctly after 
the fix:
- Single embedding: ✅ works, returns 384-dim vector
- Batch embedding with long inputs: ✅ works, returns correct embeddings