### PR TITLE
Fix: model fails to load when chat template uses HuggingFace generation tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - feat: Update llama.cpp to ggml-org/llama.cpp@d749821db
+- fix: model fails to load when chat template uses HuggingFace generation tags by @tobocop2 in #2226
 - docs: add contributing guide by @abetlen in #2229
 - chore: Migrate llama.cpp submodule URL to ggml-org/llama.cpp by @shalinib-ibm in #2034
 - fix: Enable unified KV cache for embedding contexts to preserve full per-sequence context in batch embedding calls by @SanjanaB123 in #2217

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -24,6 +24,8 @@ from typing import (
 )
 
 import jinja2
+from jinja2 import nodes
+from jinja2.ext import Extension
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 
 import numpy as np
@@ -191,6 +193,16 @@ class ChatFormatter(Protocol):
     ) -> ChatFormatterResponse: ...
 
 
+class _GenerationTagIgnore(Extension):
+    """Pass-through for HuggingFace's ``{% generation %}`` chat-template tag."""
+
+    tags = {"generation"}
+
+    def parse(self, parser: jinja2.parser.Parser) -> List[nodes.Node]:
+        parser.stream.skip(1)  # discard the 'generation' tag-name token
+        return parser.parse_statements(("name:endgeneration",), drop_needle=True)
+
+
 class Jinja2ChatFormatter(ChatFormatter):
     def __init__(
         self,
@@ -213,6 +225,7 @@ class Jinja2ChatFormatter(ChatFormatter):
             loader=jinja2.BaseLoader(),
             trim_blocks=True,
             lstrip_blocks=True,
+            extensions=[_GenerationTagIgnore],
         ).from_string(self.template)
 
     @staticmethod

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -193,7 +193,7 @@ class ChatFormatter(Protocol):
 
 
 class Jinja2ChatFormatter(ChatFormatter):
-    class _GenerationTagIgnore(Extension):
+    class IgnoreGenerationTags(Extension):
         """Pass-through for HuggingFace's ``{% generation %}`` chat-template tag."""
 
         tags = {"generation"}
@@ -223,7 +223,7 @@ class Jinja2ChatFormatter(ChatFormatter):
             loader=jinja2.BaseLoader(),
             trim_blocks=True,
             lstrip_blocks=True,
-            extensions=[Jinja2ChatFormatter._GenerationTagIgnore],
+            extensions=[Jinja2ChatFormatter.IgnoreGenerationTags],
         ).from_string(self.template)
 
     @staticmethod

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -24,7 +24,6 @@ from typing import (
 )
 
 import jinja2
-from jinja2 import nodes
 from jinja2.ext import Extension
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 
@@ -193,17 +192,16 @@ class ChatFormatter(Protocol):
     ) -> ChatFormatterResponse: ...
 
 
-class _GenerationTagIgnore(Extension):
-    """Pass-through for HuggingFace's ``{% generation %}`` chat-template tag."""
-
-    tags = {"generation"}
-
-    def parse(self, parser: jinja2.parser.Parser) -> List[nodes.Node]:
-        parser.stream.skip(1)  # discard the 'generation' tag-name token
-        return parser.parse_statements(("name:endgeneration",), drop_needle=True)
-
-
 class Jinja2ChatFormatter(ChatFormatter):
+    class _GenerationTagIgnore(Extension):
+        """Pass-through for HuggingFace's ``{% generation %}`` chat-template tag."""
+
+        tags = {"generation"}
+
+        def parse(self, parser: jinja2.parser.Parser):
+            parser.stream.skip(1)
+            return parser.parse_statements(("name:endgeneration",), drop_needle=True)
+
     def __init__(
         self,
         template: str,
@@ -225,7 +223,7 @@ class Jinja2ChatFormatter(ChatFormatter):
             loader=jinja2.BaseLoader(),
             trim_blocks=True,
             lstrip_blocks=True,
-            extensions=[_GenerationTagIgnore],
+            extensions=[Jinja2ChatFormatter._GenerationTagIgnore],
         ).from_string(self.template)
 
     @staticmethod

--- a/tests/test_llama_chat_format.py
+++ b/tests/test_llama_chat_format.py
@@ -92,26 +92,3 @@ def test_hf_tokenizer_config_str_to_chat_formatter():
     )
 
     assert chat_formatter_respoonse.prompt == ("<s>[INST] Hello, world! [/INST]</s>")
-
-
-def test_generation_tag_is_ignored() -> None:
-    """HuggingFace chat templates use {% generation %}/{% endgeneration %} to
-    mark training-time loss spans. At inference the tags must be no-ops or
-    affected GGUFs (SmolLM3 and similar) fail to load with TemplateSyntaxError.
-    """
-    template = (
-        "{% for message in messages %}"
-        "{% generation %}{{ message['role'] }}: {{ message['content'] }}{% endgeneration %}"
-        "{% endfor %}"
-    )
-    chat_formatter = llama_chat_format.Jinja2ChatFormatter(
-        template=template,
-        eos_token="</s>",
-        bos_token="<s>",
-    )
-    response = chat_formatter(
-        messages=[
-            ChatCompletionRequestUserMessage(role="user", content="hi"),
-        ]
-    )
-    assert "user: hi" in response.prompt

--- a/tests/test_llama_chat_format.py
+++ b/tests/test_llama_chat_format.py
@@ -92,3 +92,26 @@ def test_hf_tokenizer_config_str_to_chat_formatter():
     )
 
     assert chat_formatter_respoonse.prompt == ("<s>[INST] Hello, world! [/INST]</s>")
+
+
+def test_generation_tag_is_ignored() -> None:
+    """HuggingFace chat templates use {% generation %}/{% endgeneration %} to
+    mark training-time loss spans. At inference the tags must be no-ops or
+    affected GGUFs (SmolLM3 and similar) fail to load with TemplateSyntaxError.
+    """
+    template = (
+        "{% for message in messages %}"
+        "{% generation %}{{ message['role'] }}: {{ message['content'] }}{% endgeneration %}"
+        "{% endfor %}"
+    )
+    chat_formatter = llama_chat_format.Jinja2ChatFormatter(
+        template=template,
+        eos_token="</s>",
+        bos_token="<s>",
+    )
+    response = chat_formatter(
+        messages=[
+            ChatCompletionRequestUserMessage(role="user", content="hi"),
+        ]
+    )
+    assert "user: hi" in response.prompt


### PR DESCRIPTION
## Problem

GGUFs whose embedded `tokenizer.chat_template` uses `{% generation %}` / `{% endgeneration %}` (SmolLM3 and other HF-shipped models) fail to load with `TemplateSyntaxError` in `Llama.__init__`, even when the caller passes a `chat_format` override. `Jinja2ChatFormatter` eagerly compiles every embedded template.

## Solution

Register a Jinja extension that treats both tags as inert wrappers: the body renders as-is, the markers emit nothing. No behavioral change for templates that don't use the tags.

## Relationship to https://github.com/abetlen/llama-cpp-python/pull/2082

PR #2082 attempted the same approach but is incomplete:

- The `parse()` method references `nodes.Const("")` without importing `nodes` from `jinja2`, so it would `NameError` on first use.
- `parser.stream.skip(1); return nodes.Const("")` consumes only the tag name. It never advances past the body or the closing `{% endgeneration %}`, so the parser is left in a broken state and the next template construct fails to parse.

This PR addresses both: imports `nodes` and `Extension` explicitly, and consumes the body via `parser.parse_statements(("name:endgeneration",), drop_needle=True)` so the wrapped content renders and the parser advances past the closing tag. Includes a unit test that fails today and passes with the fix.

Closes #2225.