### PR TITLE
feat: update llama.cpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat: update llama.cpp to ggml-org/llama.cpp@3571fa543 by @abetlen in #2253
 - feat(ci): add ROCm wheel builds by @abetlen in #2252
 - feat(ci): add Vulkan wheel builds by @abetlen in #2251
 - fix: handle additional `from_pretrained` files in subfolders by @TNing in #2085


### PR DESCRIPTION
Updates the vendored llama.cpp submodule from ggml-org/llama.cpp@210a6570c to ggml-org/llama.cpp@3571fa543.

Notes:
- `include/llama.h` only changes `llama_set_warmup` to a deprecated declaration with the same signature.
- No mtmd header changes were found.
- No Python binding changes are required for this update.