### PR TITLE
feat: update llama.cpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat: update llama.cpp to ggml-org/llama.cpp@166fe2949 by @abetlen in #2254
 - feat: update llama.cpp to ggml-org/llama.cpp@3571fa543 by @abetlen in #2253
 - feat(ci): add ROCm wheel builds by @abetlen in #2252
 - feat(ci): add Vulkan wheel builds by @abetlen in #2251

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- feat: update llama.cpp to ggml-org/llama.cpp@166fe2949 by @abetlen in #2254
-- feat: update llama.cpp to ggml-org/llama.cpp@3571fa543 by @abetlen in #2253
+- feat: update llama.cpp to ggml-org/llama.cpp@166fe2949
 - feat(ci): add ROCm wheel builds by @abetlen in #2252
 - feat(ci): add Vulkan wheel builds by @abetlen in #2251
 - fix: handle additional `from_pretrained` files in subfolders by @TNing in #2085


### PR DESCRIPTION
Updates the vendored llama.cpp submodule from ggml-org/llama.cpp@3571fa543 to ggml-org/llama.cpp@166fe2949.