### PR TITLE
feat: update llama.cpp to ggml-org/llama.cpp@94a220cd6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- feat: update llama.cpp to ggml-org/llama.cpp@166fe2949
+- feat: update llama.cpp to ggml-org/llama.cpp@94a220cd6
 - feat(ci): add ROCm wheel builds by @abetlen in #2252
 - feat(ci): add Vulkan wheel builds by @abetlen in #2251
 - fix: handle additional `from_pretrained` files in subfolders by @TNing in #2085


### PR DESCRIPTION
Updates the vendored llama.cpp submodule to ggml-org/llama.cpp@94a220cd6.