### PR TITLE
feat: update llama.cpp to ggml-org/llama.cpp@e3ba22d6c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- feat: update llama.cpp to ggml-org/llama.cpp@94a220cd6
+- feat: update llama.cpp to ggml-org/llama.cpp@e3ba22d6c
 - feat(ci): add ROCm wheel builds by @abetlen in #2252
 - feat(ci): add Vulkan wheel builds by @abetlen in #2251
 - fix: handle additional `from_pretrained` files in subfolders by @TNing in #2085


### PR DESCRIPTION
Updates the vendored llama.cpp submodule from `94a220cd6` to `e3ba22d6c`.

Included upstream changes include:
- `fix(mtmd): handle Gemma 4 audio projector embedding size (#24091)`
- WebGPU FlashAttention refactor and quantization support updates
- Metal heartbeat reduction
- RVV quantization vec-dot updates

No public llama.cpp or mtmd header changes were detected in this bump.