### PR TITLE
feat: update llama.cpp to ggml-org/llama.cpp@465b1f0e7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- feat: update llama.cpp to ggml-org/llama.cpp@5a69c9743
+- feat: update llama.cpp to ggml-org/llama.cpp@465b1f0e7
 - feat(example): Updated server example (batch processing, multi-token prediction, `/v1/responses` api, response parsing) by @abetlen in #2174
 
 ## [0.3.26]

--- a/examples/server/server.py
+++ b/examples/server/server.py
@@ -10102,6 +10102,7 @@ class MTMDProcessor:
             self.ctx,
             buffer,
             len(media_bytes),
+            False,
         )
         if bitmap is None:
             raise CompletionRequestValidationError(f"failed to create MTMD {kind} bitmap")

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -2841,6 +2841,7 @@ class Llava15ChatHandler:
                 self.mtmd_ctx,
                 (ctypes.c_uint8 * len(image_bytes)).from_buffer(bytearray(image_bytes)),
                 len(image_bytes),
+                False,
             )
 
             if bitmap is None:
@@ -3332,6 +3333,7 @@ class MTMDChatHandler:
                 self.mtmd_ctx,
                 (ctypes.c_uint8 * len(image_bytes)).from_buffer(bytearray(image_bytes)),
                 len(image_bytes),
+                False,
             )
 
             if bitmap is None:

--- a/llama_cpp/mtmd_cpp.py
+++ b/llama_cpp/mtmd_cpp.py
@@ -551,29 +551,30 @@ def mtmd_test_create_input_chunks() -> Optional[mtmd_input_chunks_p]:
 ################################################
 
 
-# MTMD_API mtmd_bitmap * mtmd_helper_bitmap_init_from_file(mtmd_context * ctx, const char * fname);
+# MTMD_API mtmd_bitmap * mtmd_helper_bitmap_init_from_file(mtmd_context * ctx, const char * fname, bool placeholder);
 @ctypes_function(
     "mtmd_helper_bitmap_init_from_file",
-    [mtmd_context_p_ctypes, c_char_p],
+    [mtmd_context_p_ctypes, c_char_p, c_bool],
     mtmd_bitmap_p_ctypes,
 )
 def mtmd_helper_bitmap_init_from_file(
-    ctx: mtmd_context_p, fname: bytes, /
+    ctx: mtmd_context_p, fname: bytes, placeholder: Union[c_bool, bool], /
 ) -> Optional[mtmd_bitmap_p]:
     """Initialize an MTMD bitmap from a file."""
     ...
 
 
-# MTMD_API mtmd_bitmap * mtmd_helper_bitmap_init_from_buf(mtmd_context * ctx, const unsigned char * buf, size_t len);
+# MTMD_API mtmd_bitmap * mtmd_helper_bitmap_init_from_buf(mtmd_context * ctx, const unsigned char * buf, size_t len, bool placeholder);
 @ctypes_function(
     "mtmd_helper_bitmap_init_from_buf",
-    [mtmd_context_p_ctypes, POINTER(c_uint8), c_size_t],
+    [mtmd_context_p_ctypes, POINTER(c_uint8), c_size_t, c_bool],
     mtmd_bitmap_p_ctypes,
 )
 def mtmd_helper_bitmap_init_from_buf(
     ctx: mtmd_context_p,
     buf: CtypesArray[c_uint8],
     length: Union[c_size_t, int],
+    placeholder: Union[c_bool, bool],
     /,
 ) -> Optional[mtmd_bitmap_p]: ...
 


### PR DESCRIPTION
Update vendored llama.cpp to ggml-org/llama.cpp@465b1f0e7.

- Updates vendored llama.cpp from 5a69c9743 to 465b1f0e7.
- Syncs MTMD helper bitmap bindings for the new placeholder parameter.
- Updates the Unreleased changelog entry.
