### PR TITLE
chore: bump version to 0.3.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.27]
+
 - feat: update llama.cpp to ggml-org/llama.cpp@465b1f0e7
 - feat(example): Updated server example (batch processing, multi-token prediction, `/v1/responses` api, response parsing) by @abetlen in #2174
 

--- a/llama_cpp/__init__.py
+++ b/llama_cpp/__init__.py
@@ -1,4 +1,4 @@
 from .llama_cpp import *
 from .llama import *
 
-__version__ = "0.3.26"
+__version__ = "0.3.27"


### PR DESCRIPTION
Prepare the 0.3.27 release.

- Bumps `llama_cpp.__version__` to `0.3.27`.
- Moves current Unreleased entries under `0.3.27`.
