### PR TITLE
chore: bump version to 0.3.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.28]
+
 - feat(example): align server MTP support with llama.cpp by @abetlen in #2283
 - feat: update llama.cpp to ggml-org/llama.cpp@9e3b928fd
 - feat(example): add OpenAI-compatible embeddings endpoint by @abetlen in #2281

--- a/llama_cpp/__init__.py
+++ b/llama_cpp/__init__.py
@@ -1,4 +1,4 @@
 from .llama_cpp import *
 from .llama import *
 
-__version__ = "0.3.27"
+__version__ = "0.3.28"


### PR DESCRIPTION
Prepare the next llama-cpp-python release.

- Bump package version to `0.3.28`.
- Move current unreleased changelog entries under `0.3.28`.
