### PR TITLE
fix(example): avoid duplicate streamed response deltas

### DIFF
--- a/examples/server/server.py
+++ b/examples/server/server.py
@@ -8695,7 +8695,7 @@ class OpenAIFormatter:
                 state,
                 "response.output_item.added",
                 output_index=item_state.output_index,
-                item=item,
+                item=copy.deepcopy(item),
             ),
             self._response_event(
                 state,
@@ -8703,7 +8703,7 @@ class OpenAIFormatter:
                 item_id=cast(str, item["id"]),
                 output_index=item_state.output_index,
                 content_index=0,
-                part=part,
+                part=copy.deepcopy(part),
             ),
         ], item_state
 
@@ -8727,7 +8727,7 @@ class OpenAIFormatter:
                 state,
                 "response.output_item.added",
                 output_index=item_state.output_index,
-                item=item,
+                item=copy.deepcopy(item),
             ),
             self._response_event(
                 state,
@@ -8735,7 +8735,7 @@ class OpenAIFormatter:
                 item_id=cast(str, item["id"]),
                 output_index=item_state.output_index,
                 content_index=0,
-                part=part,
+                part=copy.deepcopy(part),
             ),
         ], item_state
 
@@ -8777,7 +8777,7 @@ class OpenAIFormatter:
                 state,
                 "response.output_item.added",
                 output_index=item_state.output_index,
-                item=item,
+                item=copy.deepcopy(item),
             )
         ], item_state
 


### PR DESCRIPTION
Fix streamed Responses API events from duplicating the first output delta.

- Snapshot mutable output item and content part payloads before later stream-state mutations.
- Covers reasoning text, normal output text, and tool call item-added events.
- Validated with synthetic Responses stream chunks and `python3 -m py_compile examples/server/server.py`.