### PR TITLE
feat: update llama.cpp to ggml-org/llama.cpp@ac4cddeb0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - feat(example): support server video inputs and Gemma text tool calls by @abetlen in #2291
-- feat: update llama.cpp to ggml-org/llama.cpp@76da2450a
+- feat: update llama.cpp to ggml-org/llama.cpp@ac4cddeb0
 - fix(example): support multi-step Responses tool streaming by @abetlen in #2288
 - fix(ci): Repair Linux accelerator wheels for manylinux publishing
 


### PR DESCRIPTION
Updates vendored llama.cpp to ggml-org/llama.cpp@ac4cddeb0.

- Updates the `vendor/llama.cpp` submodule.
- Keeps Python bindings unchanged because public llama/mtmd headers did not change.
- Updates the changelog.
