### PR TITLE
chore: bump version to 0.3.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.29]
+
 - feat(example): use MTMD batch encoding by @abetlen in #2301
 - feat(example): support server video inputs and Gemma text tool calls by @abetlen in #2291
 - feat: update llama.cpp to ggml-org/llama.cpp@f05cf4676

--- a/llama_cpp/__init__.py
+++ b/llama_cpp/__init__.py
@@ -1,4 +1,4 @@
 from .llama_cpp import *
 from .llama import *
 
-__version__ = "0.3.28"
+__version__ = "0.3.29"


### PR DESCRIPTION
Prepare the next llama-cpp-python release.

- Bump package version to `0.3.29`.
- Move current unreleased changelog entries under `0.3.29`.
