### PR TITLE
fix(ci): use C++ compiler for Docker builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ if (LLAMA_BUILD)
         # The Python package only ships mtmd as a shared library.
         # Upstream mtmd also defines CLI compatibility wrappers, but those are
         # not installed here and can fail to link in minimal Docker toolchains.
-        foreach(target llama-llava-cli llama-gemma3-cli llama-minicpmv-cli llama-qwen2vl-cli llama-mtmd-debug)
+        foreach(target llama-llava-cli llama-gemma3-cli llama-minicpmv-cli llama-qwen2vl-cli llama-mtmd-cli llama-mtmd-debug)
             if (TARGET ${target})
                 set_target_properties(${target} PROPERTIES EXCLUDE_FROM_ALL TRUE)
             endif()

--- a/docker/simple/Dockerfile
+++ b/docker/simple/Dockerfile
@@ -27,7 +27,7 @@ RUN python3 -m pip install --upgrade pip
 
 RUN python3 -m pip install --upgrade pip pytest cmake scikit-build setuptools fastapi uvicorn sse-starlette pydantic-settings starlette-context
 
-RUN CMAKE_ARGS="${CMAKE_ARGS}" pip install . --verbose
+RUN CC=gcc CXX=g++ CMAKE_ARGS="${CMAKE_ARGS}" pip install . --verbose
 
 # Set environment variable for the host
 ENV HOST=0.0.0.0


### PR DESCRIPTION
Fix Docker builds by forcing the package build to use the C++ compiler.

- Sets `CXX=g++` for the Docker `pip install .` build step.
- Excludes the remaining `llama-mtmd-cli` tool target from Python package builds.
- Verified CMake selects `/usr/bin/g++` and the default build graph no longer includes mtmd CLI executables.
