### PR TITLE
feat: update llama.cpp to ggml-org/llama.cpp@6e9007ae6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat: update llama.cpp to ggml-org/llama.cpp@6e9007ae6
+
 ## [0.3.29]
 
 - feat(example): use MTMD batch encoding by @abetlen in #2301


### PR DESCRIPTION
Updates vendored llama.cpp to ggml-org/llama.cpp@6e9007ae6.

- Updates `vendor/llama.cpp` from `f05cf4676` to `6e9007ae6`.
- Adds an Unreleased changelog entry.
- Leaves Python bindings unchanged because no public `llama.h`, `mtmd`, or `ggml/include` headers changed.
- Validated CMake configure and `cmake --build /tmp/llama-cpp-python-update-6e9007 --target llama`.
