### PR TITLE
feat: update llama.cpp to ggml-org/llama.cpp@6eab47181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat: update llama.cpp to ggml-org/llama.cpp@6eab47181
+
 ## [0.3.29]
 
 - feat(example): use MTMD batch encoding by @abetlen in #2301


### PR DESCRIPTION
Update vendored llama.cpp to ggml-org/llama.cpp@6eab47181.

- Includes upstream wasm fallback symbol collision fix.
- Adds the matching Unreleased changelog entry.
- No public llama.cpp, ggml, or mtmd headers changed.
