### PR TITLE
chore: bump version to 0.3.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.30]
+
 - feat: update llama.cpp to ggml-org/llama.cpp@e3a74b299
 - feat: add Pyodide wheel support by @abetlen in #2309
 

--- a/llama_cpp/__init__.py
+++ b/llama_cpp/__init__.py
@@ -1,4 +1,4 @@
 from .llama_cpp import *
 from .llama import *
 
-__version__ = "0.3.29"
+__version__ = "0.3.30"


### PR DESCRIPTION
Prepare the 0.3.30 release.

- Bumps `llama_cpp.__version__` to `0.3.30`.
- Moves Unreleased changelog entries under `0.3.30`.
