### PR TITLE
feat: update llama.cpp to f449e0553

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat: update llama.cpp to ggml-org/llama.cpp@f3e182816
+
 ## [0.3.30]
 
 - feat: update llama.cpp to ggml-org/llama.cpp@e3a74b299

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- feat: update llama.cpp to ggml-org/llama.cpp@f3e182816
+- feat: update llama.cpp to ggml-org/llama.cpp@4b4d13ae7
 
 ## [0.3.30]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- feat: update llama.cpp to ggml-org/llama.cpp@4b4d13ae7
+- feat: update llama.cpp to ggml-org/llama.cpp@f449e0553
 
 ## [0.3.30]
 


### PR DESCRIPTION
Updates the vendored llama.cpp submodule to ggml-org/llama.cpp@f449e0553.

- Updates the submodule from `e3a74b299` to `f449e0553`.
- Includes the upstream Metal BF16 concat fix from llama.cpp #24747.
- Updates the Unreleased changelog entry.
