### PR TITLE
chore: bump version to 0.3.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.31]
+
 - feat: update llama.cpp to ggml-org/llama.cpp@f449e0553
 
 ## [0.3.30]

--- a/llama_cpp/__init__.py
+++ b/llama_cpp/__init__.py
@@ -1,4 +1,4 @@
 from .llama_cpp import *
 from .llama import *
 
-__version__ = "0.3.30"
+__version__ = "0.3.31"


### PR DESCRIPTION
Prepares the 0.3.31 release.

- Bumps `llama_cpp.__version__` to `0.3.31`.
- Moves the current Unreleased changelog entry under `0.3.31`.
