### PR TITLE
feat: update llama.cpp to b3fed31b9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - feat(example): support chained NextN heads for server MTP drafting
-- feat: update llama.cpp to ggml-org/llama.cpp@92e854ab8
+- feat: update llama.cpp to ggml-org/llama.cpp@fdbd6abee
 - fix: preserve recurrent/hybrid model state when the full prompt is already cached by @allthatido and @abetlen in #2306
 
 ## [0.3.31]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - feat(example): support chained NextN heads for server MTP drafting
-- feat: update llama.cpp to ggml-org/llama.cpp@fdbd6abee
+- feat: update llama.cpp to ggml-org/llama.cpp@b3fed31b9
 - fix: preserve recurrent/hybrid model state when the full prompt is already cached by @allthatido and @abetlen in #2306
 
 ## [0.3.31]


### PR DESCRIPTION
Updates the vendored llama.cpp submodule.

- Updates llama.cpp to ggml-org/llama.cpp@b3fed31b9.
- Leaves Python bindings unchanged because public headers did not change.
- Updates the changelog entry.
