### PR TITLE
fix(mtmd): join text-only content parts for passthrough chat templates

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -3368,10 +3368,19 @@ class MTMDChatHandler:
         message_dict = dict(message)
         content = message_dict.get("content")
         if isinstance(content, list):
-            message_dict["content"] = [
+            converted = [
                 cls._convert_content_part_for_template(part, media_marker)
                 for part in content
             ]
+            if all(
+                isinstance(p, dict) and p.get("type") == "text"
+                for p in converted
+            ):
+                message_dict["content"] = "".join(
+                    p.get("text", "") for p in converted
+                )
+            else:
+                message_dict["content"] = converted
         return message_dict
 
     @staticmethod


### PR DESCRIPTION
## Problem

`MTMDChatHandler._convert_message_for_template` keeps multimodal content as a list of dicts after media marker substitution. For models with passthrough chat templates (e.g., `{% for m in messages %}{{m['content']}}{% endfor %}`), Jinja renders this list as its Python repr string. The model receives garbled input and produces 0 output tokens (immediate EOS).

Affects any model whose `tokenizer.chat_template` directly references `m['content']` or `m.content` without iterating over content parts. Confirmed on Baidu Unlimited-OCR (deepseek2-ocr architecture, 4.6K GitHub stars).

## Fix

After converting content parts (replacing image_url with the media marker text), check if all parts resolved to text-only dicts. If so, join them into a single concatenated string. Templates that iterate over content parts (e.g., LLaVA-style `{% for item in message.content %}`) are unaffected because the else-branch preserves the list.

## Before / After

**Before (0 output tokens):**
```
$ python3 -c "result = llm.create_chat_completion(...); print(result['choices'][0]['message']['content'])"
# (empty string)
```

**After (correct structured OCR with bounding boxes):**
```
header [20, 43, 243, 104]INVOICE #1234
header [23, 116, 297, 174]Date: June 26, 2026
text [23, 468, 377, 528]Widget A 5 $10.00
text [24, 538, 390, 598]Widget B 10 $25.00
text [24, 608, 387, 670]Gadget C 2 $50.00
text [20, 748, 387, 810]Subtotal: $350.00
text [23, 818, 411, 882]Tax (8.875%): $31.06
text [24, 888, 367, 948]Total: $381.06
```

## Test environment

- llama-cpp-python 0.3.31
- macOS ARM64 (M4 Pro), Metal
- Model: Unlimited-OCR Q4_K_M + mmproj-F16 (sahilchachra/Unlimited-OCR-GGUF)
- Also verified with `llama-mtmd-cli --jinja` (native C++ binary produces identical output, confirming the fix matches upstream behavior)