### PR TITLE
chore: bump version to 0.3.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.32]
+
 - feat(example): support chained NextN heads for server MTP drafting
 - feat: update llama.cpp to ggml-org/llama.cpp@b3fed31b9
 - fix: preserve recurrent/hybrid model state when the full prompt is already cached by @allthatido and @abetlen in #2306

--- a/llama_cpp/__init__.py
+++ b/llama_cpp/__init__.py
@@ -1,4 +1,4 @@
 from .llama_cpp import *
 from .llama import *
 
-__version__ = "0.3.31"
+__version__ = "0.3.32"


### PR DESCRIPTION
Prepares the 0.3.32 release.

- Bumps llama-cpp-python to 0.3.32.
- Promotes the Unreleased changelog entries to 0.3.32.
