### PR TITLE
chore: bump version to 0.3.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.34]
+
 ## [0.3.33]
 
 - feat: update llama.cpp to ggml-org/llama.cpp@78d2f5246

--- a/llama_cpp/__init__.py
+++ b/llama_cpp/__init__.py
@@ -1,4 +1,4 @@
 from .llama_cpp import *
 from .llama import *
 
-__version__ = "0.3.33"
+__version__ = "0.3.34"


### PR DESCRIPTION
Prepares the 0.3.34 release.

- Bumps llama-cpp-python to 0.3.34.
- Promotes the Unreleased changelog entries to 0.3.34.