### PR TITLE
feat: update llama.cpp to e3546c794

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat: update llama.cpp to ggml-org/llama.cpp@13f2b28b0
+
 ## [0.3.33]
 
 - feat: update llama.cpp to ggml-org/llama.cpp@78d2f5246

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- feat: update llama.cpp to ggml-org/llama.cpp@13f2b28b0
+- feat: update llama.cpp to ggml-org/llama.cpp@e3546c794
 
 ## [0.3.33]
 

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -89,7 +89,8 @@ def _warn_deprecated(symbol: str, hint: str) -> None:
 #     GGML_TYPE_MXFP4   = 39,
 #     GGML_TYPE_NVFP4   = 40,
 #     GGML_TYPE_Q1_0    = 41,
-#     GGML_TYPE_COUNT   = 42,
+#     GGML_TYPE_Q2_0    = 42,
+#     GGML_TYPE_COUNT   = 43,
 # };
 GGML_TYPE_F32 = 0
 GGML_TYPE_F16 = 1
@@ -122,7 +123,8 @@ GGML_TYPE_IQ1_M = 29
 GGML_TYPE_MXFP4 = 39
 GGML_TYPE_NVFP4 = 40
 GGML_TYPE_Q1_0 = 41
-GGML_TYPE_COUNT = 42
+GGML_TYPE_Q2_0 = 42
+GGML_TYPE_COUNT = 43
 
 # from ggml-backend.h
 # typedef bool (*ggml_backend_sched_eval_callback)(struct ggml_tensor * t, bool ask, void * user_data);
@@ -411,6 +413,7 @@ LLAMA_TOKEN_ATTR_SINGLE_WORD = 1 << 9
 #     LLAMA_FTYPE_MOSTLY_MXFP4_MOE     = 38, // except 1d tensors
 #     LLAMA_FTYPE_MOSTLY_NVFP4         = 39, // except 1d tensors
 #     LLAMA_FTYPE_MOSTLY_Q1_0          = 40, // except 1d tensors
+#     LLAMA_FTYPE_MOSTLY_Q2_0          = 41, // except 1d tensors
 #
 #     LLAMA_FTYPE_GUESSED = 1024, // not specified in the model file
 # };
@@ -452,6 +455,7 @@ LLAMA_FTYPE_MOSTLY_TQ2_0 = 37
 LLAMA_FTYPE_MOSTLY_MXFP4_MOE = 38
 LLAMA_FTYPE_MOSTLY_NVFP4 = 39
 LLAMA_FTYPE_MOSTLY_Q1_0 = 40
+LLAMA_FTYPE_MOSTLY_Q2_0 = 41
 LLAMA_FTYPE_GUESSED = 1024
 
 # enum llama_rope_scaling_type {


### PR DESCRIPTION
Updates the vendored llama.cpp revision and synchronizes the affected Python bindings.

- Advances llama.cpp from 78d2f5246 to e3546c794.
- Adds the Q2_0 GGML type and llama model file-type constants.
- Validates the CPU and MTMD build plus targeted Python tests.