### PR TITLE
ci: run release workflows for version tags

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -1,6 +1,10 @@
 name: Build Release
 
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,6 +1,10 @@
 name: Build Docker
 
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/build-wheels-cuda.yaml
+++ b/.github/workflows/build-wheels-cuda.yaml
@@ -1,6 +1,9 @@
 name: Build Wheels (CUDA)
 
 on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       release_tag:

--- a/.github/workflows/build-wheels-metal.yaml
+++ b/.github/workflows/build-wheels-metal.yaml
@@ -1,6 +1,10 @@
 name: Build Wheels (Metal)
 
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/build-wheels-rocm.yaml
+++ b/.github/workflows/build-wheels-rocm.yaml
@@ -1,6 +1,9 @@
 name: Build Wheels (ROCm)
 
 on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       release_tag:

--- a/.github/workflows/build-wheels-vulkan.yaml
+++ b/.github/workflows/build-wheels-vulkan.yaml
@@ -1,6 +1,9 @@
 name: Build Wheels (Vulkan)
 
 on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       release_tag:

--- a/.github/workflows/generate-index-from-release.yaml
+++ b/.github/workflows/generate-index-from-release.yaml
@@ -3,7 +3,7 @@ name: Wheels Index
 on:
   # Trigger on new release
   workflow_run:
-    workflows: ["Release", "Build Wheels (CUDA)", "Build Wheels (Metal)", "Build Wheels (Vulkan)", "Build Wheels (ROCm)"]
+    workflows: ["Build Release", "Build Wheels (CUDA)", "Build Wheels (Metal)", "Build Wheels (Vulkan)", "Build Wheels (ROCm)"]
     types:
       - completed
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,11 @@ name: Publish to PyPI
 
 # Based on: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
 
 jobs:
   build-n-publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ci: run release workflows for version tags by @abetlen in #2339
+
 ## [0.3.34]
 
 - feat: update llama.cpp to ggml-org/llama.cpp@e3546c794


### PR DESCRIPTION
Runs the complete release pipeline automatically when a version tag is pushed.

- Triggers PyPI, release wheels, accelerator wheels, and Docker for semantic version tags.
- Preserves manual workflow dispatch for retries and recovery.
- Fixes the wheel-index trigger to reference the Build Release workflow.
- Validated with actionlint.