### PR TITLE
feat: expose progress_callback in Llama wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat: update llama.cpp to ggml-org/llama.cpp@e3546c794
+
 ## [0.3.34]
 
 - feat: update llama.cpp to ggml-org/llama.cpp@e3546c794

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- feat: update llama.cpp to ggml-org/llama.cpp@e3546c794
+- feat: exposes progress_callback and progress_callback_user_data through the high-level Llama constructor
 
 ## [0.3.34]
 

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -114,6 +114,9 @@ class Llama:
         # KV cache quantization
         type_k: Optional[int] = None,
         type_v: Optional[int] = None,
+        # Progress callback
+        progress_callback: Optional[Callable[[float, Any], bool]] = None,
+        progress_callback_user_data: Optional[Any] = None,
         # Misc
         spm_infill: bool = False,
         verbose: bool = True,
@@ -190,6 +193,8 @@ class Llama:
             verbose: Print verbose output to stderr.
             type_k: KV cache data type for K (default: f16)
             type_v: KV cache data type for V (default: f16)
+            progress_callback: Optional callback invoked during model loading. Signature: callback(progress: float, user_data: Any) -> bool, progress is a value between 0.0 and 1.0. Returning False aborts model loading
+            progress_callback_user_data: Optional context pointer passed to progress_callback.
             spm_infill: Use Suffix/Prefix/Middle pattern for infill (instead of Prefix/Suffix/Middle) as some models prefer this.
 
         Raises:
@@ -246,6 +251,17 @@ class Llama:
         self.model_params.vocab_only = vocab_only
         self.model_params.use_mmap = use_mmap if lora_path is None else False
         self.model_params.use_mlock = use_mlock
+
+        # Progress callback
+        if progress_callback is not None:
+            self._progress_callback = llama_cpp.llama_progress_callback(
+                progress_callback
+            )
+            self.model_params.progress_callback = self._progress_callback
+        if progress_callback_user_data is not None:
+            self.model_params.progress_callback_user_data = (
+                progress_callback_user_data
+            )
 
         # kv_overrides is the original python dict
         self.kv_overrides = kv_overrides


### PR DESCRIPTION
Exposes `progress_callback` and `progress_callback_user_data` through the high-level Llama constructor.

`llama_model_params` already supports these fields, and the ctype bindings already expose them, but they are not currently available through the `Llama` API. 

This allows Python applications to receive model loading progress and optionally abort model loading by returning `False` from the callback, consistent with the underlying llama.cpp API.

## Implementation

- Add `progress_callback` and `progress_callback_user_data` to the `Llama` constructor
- Wrap the supplied Python callback with `llama_progress_callback`
- Store the wrapped callback on the `Llama` instance to prevent it from being garbage collected before model loading completes.

## Testing

This change was tested by successfully receiving model loading progress callbacks and aborting model loading by returning False from the callback.