### PR TITLE
fix(llama): release a vision chat handler's mtmd context on close (#2342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(example): retain recurrent state for server MTP rollback
 - feat: update llama.cpp to ggml-org/llama.cpp@adb55e514
 - fix(server): show falsey defaults in CLI help by @cupkk in #2355
+- fix: release multimodal contexts when closing Llama by @Anai-Guo in #2343
 
 ## [0.3.34]
 

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -463,6 +463,16 @@ class Llama:
 
         self.chat_format = chat_format
         self.chat_handler = chat_handler
+        # A vision chat handler builds its mtmd/clip context from this model, so
+        # that context must be released before the model itself is freed.  The
+        # handler object can outlive the Llama (callers commonly reuse a single
+        # handler across loads), and it skips re-initialization while mtmd_ctx
+        # is set -- leaving a context bound to an already-freed model behind.
+        # `_stack` unwinds LIFO, so this runs before the model teardown that was
+        # registered earlier in __init__.
+        handler_stack = getattr(chat_handler, "_exit_stack", None)
+        if handler_stack is not None:
+            self._stack.callback(handler_stack.close)
         self._chat_handlers: Dict[
             str, llama_chat_format.LlamaChatCompletionHandler
         ] = {}

--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -463,16 +463,6 @@ class Llama:
 
         self.chat_format = chat_format
         self.chat_handler = chat_handler
-        # A vision chat handler builds its mtmd/clip context from this model, so
-        # that context must be released before the model itself is freed.  The
-        # handler object can outlive the Llama (callers commonly reuse a single
-        # handler across loads), and it skips re-initialization while mtmd_ctx
-        # is set -- leaving a context bound to an already-freed model behind.
-        # `_stack` unwinds LIFO, so this runs before the model teardown that was
-        # registered earlier in __init__.
-        handler_stack = getattr(chat_handler, "_exit_stack", None)
-        if handler_stack is not None:
-            self._stack.callback(handler_stack.close)
         self._chat_handlers: Dict[
             str, llama_chat_format.LlamaChatCompletionHandler
         ] = {}

--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -9,7 +9,6 @@ import random
 import string
 
 from datetime import datetime
-from contextlib import ExitStack
 from typing import (
     Any,
     Dict,
@@ -2779,7 +2778,6 @@ class Llava15ChatHandler:
         self.clip_model_path = clip_model_path
         self.verbose = verbose
         self._mtmd_cpp = mtmd_cpp
-        self._exit_stack = ExitStack()
         self.mtmd_ctx: Optional[mtmd_cpp.mtmd_context_p] = None
 
         if not os.path.exists(clip_model_path):
@@ -2825,7 +2823,7 @@ class Llava15ChatHandler:
                         self._mtmd_cpp.mtmd_free(self.mtmd_ctx)
                         self.mtmd_ctx = None
 
-            self._exit_stack.callback(mtmd_free)
+            llama_model._stack.callback(mtmd_free)
 
     def load_image(self, image_url: str) -> bytes:
         return self._load_image(image_url)
@@ -3278,7 +3276,6 @@ class MTMDChatHandler:
         self.verbose = verbose
         self.use_gpu = use_gpu
         self._mtmd_cpp = mtmd_cpp
-        self._exit_stack = ExitStack()
         self.mtmd_ctx: Optional[mtmd_cpp.mtmd_context_p] = None
 
         if not os.path.exists(clip_model_path):
@@ -3321,7 +3318,7 @@ class MTMDChatHandler:
                         self._mtmd_cpp.mtmd_free(self.mtmd_ctx)
                         self.mtmd_ctx = None
 
-            self._exit_stack.callback(mtmd_free)
+            llama_model._stack.callback(mtmd_free)
 
     def load_image(self, image_url: str) -> bytes:
         return self._load_image(image_url)


### PR DESCRIPTION
Fixes #2342.

- Register MTMD context cleanup on the `Llama` instance whose model created it.
- Release the context before model teardown and reset the handler for reuse.
- Avoid making `Llama` own arbitrary resources from custom chat handlers.