### PR TITLE
fix: skip CUDA_PATH / HIP_PATH DLL directories that do not exist

### DIFF
--- a/llama_cpp/_ctypes_extensions.py
+++ b/llama_cpp/_ctypes_extensions.py
@@ -60,12 +60,14 @@ def load_shared_library(lib_base_name: str, base_path: pathlib.Path):
 
     if sys.platform == "win32" and sys.version_info >= (3, 8):
         os.add_dll_directory(str(base_path))
-        if "CUDA_PATH" in os.environ:
-            os.add_dll_directory(os.path.join(os.environ["CUDA_PATH"], "bin"))
-            os.add_dll_directory(os.path.join(os.environ["CUDA_PATH"], "lib"))
-        if "HIP_PATH" in os.environ:
-            os.add_dll_directory(os.path.join(os.environ["HIP_PATH"], "bin"))
-            os.add_dll_directory(os.path.join(os.environ["HIP_PATH"], "lib"))
+        for toolkit_env_var in ("CUDA_PATH", "HIP_PATH"):
+            toolkit_path = os.environ.get(toolkit_env_var)
+            if toolkit_path is None:
+                continue
+            for sub_dir in ("bin", "lib"):
+                full_path = os.path.join(toolkit_path, sub_dir)
+                if os.path.exists(full_path):
+                    os.add_dll_directory(full_path)
         cdll_args["winmode"] = ctypes.RTLD_GLOBAL
 
     if sys.platform == "emscripten":


### PR DESCRIPTION
## Problem

On Windows, `os.add_dll_directory()` raises `FileNotFoundError: [WinError 3]` if the path does not exist. In `llama_cpp/_ctypes_extensions.py` the `CUDA_PATH` and `HIP_PATH` sub-directories are passed to it unconditionally.

So if either variable points at a toolkit the user has since uninstalled, upgraded, or moved, `import llama_cpp` fails outright — before any user code runs, and regardless of whether that backend is even in use:

```
FileNotFoundError: [WinError 3] The system cannot find the path specified:
'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\11.2\bin'
```

Repro on any Windows machine:

```python
import os
os.environ["CUDA_PATH"] = r"C:\does\not\exist"
import llama_cpp  # FileNotFoundError [WinError 3]
```

A stale toolkit variable is common — CUDA upgrades in particular tend to leave the old `CUDA_PATH` behind — and because the failure surfaces inside the loader rather than at the offending variable, it reads as a broken wheel or a broken install.

This was reported in #1077: `CUDA_PATH` pointed at an uninstalled CUDA 11.2 while 12.3 was actually installed. That issue was closed after the reporter corrected their environment, but the loader itself was never changed, so it still happens today.

## Solution

Check each candidate directory with `os.path.exists()` before registering it.

Both variables use the same `bin` / `lib` sub-directories, so the two near-identical blocks collapse into one loop. Each directory is tested individually, which also means a partially removed toolkit contributes whichever of `bin` / `lib` survive instead of raising.

No behaviour change for a valid toolkit: every directory registered today is still registered.

## Notes

- Verified: stale path (nothing added, no raise), valid toolkit (both dirs added), partially removed (surviving dir added), variable unset, variable set to an empty string.
- `os.environ.get(...) is None` is used rather than `in os.environ` so an empty-string value is handled as well.