### PR TITLE
feat: update llama.cpp to adb55e514

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- feat: update llama.cpp to ggml-org/llama.cpp@936918514
+- feat: update llama.cpp to ggml-org/llama.cpp@adb55e514
 
 ## [0.3.34]
 

--- a/llama_cpp/llama_cpp.py
+++ b/llama_cpp/llama_cpp.py
@@ -521,12 +521,14 @@ LLAMA_SPLIT_MODE_TENSOR = 3
 
 
 # enum llama_load_mode {
-#     LLAMA_LOAD_MODE_NONE       = 0, // no special loading mode
-#     LLAMA_LOAD_MODE_MMAP       = 1, // memory map the model
-#     LLAMA_LOAD_MODE_MLOCK      = 2, // force system to keep model in RAM rather than swapping or compressing
-#     LLAMA_LOAD_MODE_MMAP_MLOCK = 3, // mmap + force system to keep model in RAM rather than swapping or compressing
-#     LLAMA_LOAD_MODE_DIRECT_IO  = 4, // use direct I/O if available
+#     LLAMA_LOAD_MODE_AUTO       = -1, // auto-detect based on device capabilities
+#     LLAMA_LOAD_MODE_NONE       =  0, // no special loading mode
+#     LLAMA_LOAD_MODE_MMAP       =  1, // memory map the model
+#     LLAMA_LOAD_MODE_MLOCK      =  2, // force system to keep model in RAM rather than swapping or compressing
+#     LLAMA_LOAD_MODE_MMAP_MLOCK =  3, // mmap + force system to keep model in RAM rather than swapping or compressing
+#     LLAMA_LOAD_MODE_DIRECT_IO  =  4, // use direct I/O if available
 # };
+LLAMA_LOAD_MODE_AUTO = -1
 LLAMA_LOAD_MODE_NONE = 0
 LLAMA_LOAD_MODE_MMAP = 1
 LLAMA_LOAD_MODE_MLOCK = 2
@@ -912,14 +914,15 @@ class llama_sampler_seq_config(ctypes.Structure):
 # // NOTE: changing the default values of parameters marked as [EXPERIMENTAL] may cause crashes or incorrect results in certain configurations
 # //       https://github.com/ggml-org/llama.cpp/pull/7544
 # struct llama_context_params {
-#     uint32_t n_ctx;             // text context, 0 = from model
-#     uint32_t n_batch;           // logical maximum batch size that can be submitted to llama_decode
-#     uint32_t n_ubatch;          // physical maximum batch size
-#     uint32_t n_seq_max;         // max number of sequences (i.e. distinct states for recurrent models)
-#     uint32_t n_rs_seq;          // number of recurrent-state snapshots per seq for rollback (0 = no rollback) [EXPERIMENTAL]
-#     uint32_t n_outputs_max;     // max outputs in a ubatch (0 = n_batch)
-#     int32_t  n_threads;         // number of threads to use for generation
-#     int32_t  n_threads_batch;   // number of threads to use for batch processing
+#     uint32_t n_ctx;                 // text context, 0 = from model
+#     uint32_t n_batch;               // logical maximum batch size that can be submitted to llama_decode
+#     uint32_t n_ubatch;              // physical maximum batch size
+#     uint32_t n_seq_max;             // max number of sequences (i.e. distinct states for recurrent models)
+#     uint32_t n_rs_seq;              // number of recurrent-state snapshots per seq for rollback (0 = no rollback) [EXPERIMENTAL]
+#     uint32_t n_outputs_max;         // max outputs in a ubatch (0 = n_batch)
+#     uint32_t n_outputs_max_per_seq; // max outputs per sequence (0 = n_outputs_max)
+#     int32_t  n_threads;             // number of threads to use for generation
+#     int32_t  n_threads_batch;       // number of threads to use for batch processing
 
 #     enum llama_context_type      ctx_type;          // set the context type (e.g. MTP)
 #     enum llama_rope_scaling_type rope_scaling_type; // RoPE scaling type, from `enum llama_rope_scaling_type`
@@ -978,6 +981,7 @@ class llama_context_params(ctypes.Structure):
         n_seq_max (int): max number of sequences (i.e. distinct states for recurrent models)
         n_rs_seq (int): number of recurrent-state snapshots per sequence for rollback
         n_outputs_max (int): max outputs in a ubatch, 0 = n_batch
+        n_outputs_max_per_seq (int): max outputs per sequence, 0 = n_outputs_max
         n_threads (int): number of threads to use for generation
         n_threads_batch (int): number of threads to use for batch processing
         ctx_type (int): context type, from `enum llama_context_type`
@@ -1017,6 +1021,7 @@ class llama_context_params(ctypes.Structure):
         n_seq_max: int
         n_rs_seq: int
         n_outputs_max: int
+        n_outputs_max_per_seq: int
         n_threads: int
         n_threads_batch: int
         ctx_type: int
@@ -1055,6 +1060,7 @@ class llama_context_params(ctypes.Structure):
         ("n_seq_max", ctypes.c_uint32),
         ("n_rs_seq", ctypes.c_uint32),
         ("n_outputs_max", ctypes.c_uint32),
+        ("n_outputs_max_per_seq", ctypes.c_uint32),
         ("n_threads", ctypes.c_int32),
         ("n_threads_batch", ctypes.c_int32),
         ("ctx_type", ctypes.c_int),
@@ -1232,6 +1238,13 @@ class llama_chat_message(ctypes.Structure):
 # struct llama_adapter_lora;
 llama_adapter_lora_p = ctypes.c_void_p
 llama_adapter_lora_p_ctypes = ctypes.POINTER(ctypes.c_void_p)
+
+
+# LLAMA_API const char * llama_version(void);
+@ctypes_function("llama_version", [], ctypes.c_char_p)
+def llama_version() -> bytes:
+    """Get the llama.cpp version."""
+    ...
 
 
 # // Helpers for getting default parameters
@@ -2891,6 +2904,7 @@ def llama_state_seq_save_file(
 ) -> int: ...
 
 
+# // If tokens_out is None, only the token count is reported through n_token_count_out and no state is loaded
 # LLAMA_API size_t llama_state_seq_load_file(
 #         struct llama_context * ctx,
 #                   const char * filepath,
@@ -3331,6 +3345,9 @@ def llama_get_embeddings_seq(
 
 
 # // Get the backend sampled token for the ith token.
+# // With multiple outputs, sampler state advances when the token is accepted,
+# // not when it is read through this function.
+# // When accepting multiple outputs, accept a contiguous prefix in output order.
 # // Returns LLAMA_TOKEN_NULL if no token was sampled.
 # LLAMA_API llama_token llama_get_sampled_token_ith(struct llama_context * ctx, int32_t i);
 @ctypes_function(
@@ -4317,7 +4334,7 @@ llama_sampler_i_reset = ctypes.CFUNCTYPE(None, llama_sampler_p_ctypes)
 llama_sampler_i_clone = ctypes.CFUNCTYPE(llama_sampler_p_ctypes, llama_sampler_p_ctypes)
 llama_sampler_i_free = ctypes.CFUNCTYPE(None, llama_sampler_p_ctypes)
 llama_sampler_i_backend_init = ctypes.CFUNCTYPE(
-    ctypes.c_bool, llama_sampler_p_ctypes, ctypes.c_void_p
+    ctypes.c_bool, llama_sampler_p_ctypes, ctypes.c_void_p, ctypes.c_uint32
 )
 llama_sampler_i_backend_accept = ctypes.CFUNCTYPE(
     None,
@@ -4334,6 +4351,10 @@ llama_sampler_i_backend_apply = ctypes.CFUNCTYPE(
     ctypes.POINTER(llama_sampler_data),
 )
 llama_sampler_i_backend_set_input = ctypes.CFUNCTYPE(None, llama_sampler_p_ctypes)
+llama_sampler_i_backend_reset = ctypes.CFUNCTYPE(None, llama_sampler_p_ctypes)
+llama_sampler_i_copy_state = ctypes.CFUNCTYPE(
+    None, llama_sampler_p_ctypes, llama_sampler_p_ctypes
+)
 
 llama_sampler_i._fields_ = [
     ("name", llama_sampler_i_name),
@@ -4346,6 +4367,8 @@ llama_sampler_i._fields_ = [
     ("backend_accept", llama_sampler_i_backend_accept),
     ("backend_apply", llama_sampler_i_backend_apply),
     ("backend_set_input", llama_sampler_i_backend_set_input),
+    ("backend_reset", llama_sampler_i_backend_reset),
+    ("copy_state", llama_sampler_i_copy_state),
 ]
 
 
@@ -4420,6 +4443,15 @@ def llama_sampler_reset(smpl: llama_sampler_p, /): ...
     llama_sampler_p_ctypes,
 )
 def llama_sampler_clone(smpl: llama_sampler_p, /) -> llama_sampler_p: ...
+
+
+# LLAMA_API void                   llama_sampler_copy  (const struct llama_sampler * src, struct llama_sampler * dst);
+@ctypes_function(
+    "llama_sampler_copy",
+    [llama_sampler_p_ctypes, llama_sampler_p_ctypes],
+    None,
+)
+def llama_sampler_copy(src: llama_sampler_p, dst: llama_sampler_p, /): ...
 
 
 # // important: do not free if the sampler has been added to a llama_sampler_chain (via llama_sampler_chain_add)
@@ -4835,6 +4867,7 @@ def llama_sampler_get_seed(smpl: llama_sampler_p, /) -> int: ...
 
 
 # /// @details Sample and accept a token from the idx-th output of the last evaluation
+# // For multiple outputs from one sampler, call this function in output order without gaps.
 # LLAMA_API llama_token llama_sampler_sample(struct llama_sampler * smpl, struct llama_context * ctx, int32_t idx);
 @ctypes_function(
     "llama_sampler_sample",

--- a/llama_cpp/mtmd_cpp.py
+++ b/llama_cpp/mtmd_cpp.py
@@ -93,6 +93,7 @@ MTMD_INPUT_CHUNK_TYPE_COUNT = 3
 
 MTMD_GEN_AUDIO_TYPE_NONE = 0
 MTMD_GEN_AUDIO_TYPE_QWEN3TTS = 1
+MTMD_GEN_AUDIO_TYPE_POCKETTTS = 2
 
 MTMD_GEN_PROCESS_TYPE_GEN_CODE = 0
 MTMD_GEN_PROCESS_TYPE_GEN_WAV = 1
@@ -193,15 +194,18 @@ class mtmd_caps(Structure):
 # struct mtmd_gen_audio_info {
 #     enum mtmd_gen_audio_type type;
 #     int32_t sample_rate; // in Hz, for example 24000 for qwen3tts
+#     const char * model_variant; // name of the weight variant, can be None if not applicable
 # };
 class mtmd_gen_audio_info(Structure):
     if TYPE_CHECKING:
         type: int
         sample_rate: int
+        model_variant: Optional[bytes]
 
     _fields_ = [
         ("type", c_int),
         ("sample_rate", c_int32),
+        ("model_variant", c_char_p),
     ]
 
 
@@ -213,10 +217,15 @@ class mtmd_gen_audio_info(Structure):
 #     float * embd;   // the hidden state from backbone, must have n_text_embd elements
 #     int32_t top_k;
 #     float   top_p;
+#     uint32_t seed; // UINT32_MAX for random
+#     float    temp; // sampling temperature, or noise scale for flow-matching decoders
 #
 #     // for MTMD_GEN_PROCESS_TYPE_GEN_WAV
+#     // pass either codes (discrete) or feats (continuous), depending on the pipeline
 #     int32_t * codes;
 #     size_t    n_codes;
+#     const float * feats;
+#     size_t        n_feats;
 #     const char * state_data;
 #     size_t       state_size;
 # };
@@ -227,8 +236,12 @@ class mtmd_gen_inp(Structure):
         embd: Optional["_Pointer[c_float]"]
         top_k: int
         top_p: float
+        seed: int
+        temp: float
         codes: Optional["_Pointer[c_int32]"]
         n_codes: int
+        feats: Optional["_Pointer[c_float]"]
+        n_feats: int
         state_data: Optional["_Pointer[c_char]"]
         state_size: int
 
@@ -238,8 +251,12 @@ class mtmd_gen_inp(Structure):
         ("embd", POINTER(c_float)),
         ("top_k", c_int32),
         ("top_p", c_float),
+        ("seed", c_uint32),
+        ("temp", c_float),
         ("codes", POINTER(c_int32)),
         ("n_codes", c_size_t),
+        ("feats", POINTER(c_float)),
+        ("n_feats", c_size_t),
         ("state_data", POINTER(c_char)),
         ("state_size", c_size_t),
     ]
@@ -250,9 +267,12 @@ class mtmd_gen_inp(Structure):
 #
 #     // for MTMD_GEN_PROCESS_TYPE_GEN_CODE
 #     const int32_t * codes;
-#     size_t n_codes;
+#     size_t          n_codes;
+#     const float * feats; // continuous counterpart of codes
+#     size_t        n_feats;
 #     const float * embd; // the generated hidden state, to be fed back to backbone
 #                         // it must have n_text_embd elements
+#     bool is_eos; // only set by pipelines having the EOS head inside mmproj
 #
 #     // for MTMD_GEN_PROCESS_TYPE_GEN_WAV
 #     const float * audio;
@@ -264,7 +284,10 @@ class mtmd_gen_out(Structure):
     if TYPE_CHECKING:
         codes: Optional["_Pointer[c_int32]"]
         n_codes: int
+        feats: Optional["_Pointer[c_float]"]
+        n_feats: int
         embd: Optional["_Pointer[c_float]"]
+        is_eos: bool
         audio: Optional["_Pointer[c_float]"]
         n_samples: int
         state_data: Optional["_Pointer[c_char]"]
@@ -273,7 +296,10 @@ class mtmd_gen_out(Structure):
     _fields_ = [
         ("codes", POINTER(c_int32)),
         ("n_codes", c_size_t),
+        ("feats", POINTER(c_float)),
+        ("n_feats", c_size_t),
         ("embd", POINTER(c_float)),
+        ("is_eos", c_bool),
         ("audio", POINTER(c_float)),
         ("n_samples", c_size_t),
         ("state_data", POINTER(c_char)),
@@ -350,8 +376,9 @@ class mtmd_helper_video_init_params(Structure):
 #     mtmd_bitmap * speaker_ref; // optional, can be NULL
 #     const char * lang; // optional, can be NULL
 #
-#     int32_t top_k;
-#     float   top_p;
+#     int32_t  top_k;
+#     float    top_p;
+#     uint32_t seed; // UINT32_MAX for random (default: random)
 #
 #     enum mtmd_helper_gen_audio_outtype out_type;
 # };
@@ -364,6 +391,7 @@ class mtmd_helper_gen_audio_inp(Structure):
         lang: Optional[bytes]
         top_k: int
         top_p: float
+        seed: int
         out_type: int
 
     _fields_ = [
@@ -374,6 +402,7 @@ class mtmd_helper_gen_audio_inp(Structure):
         ("lang", c_char_p),
         ("top_k", c_int32),
         ("top_p", c_float),
+        ("seed", c_uint32),
         ("out_type", c_int),
     ]
 
@@ -891,6 +920,18 @@ def mtmd_gen_audio_get_info(ctx: mtmd_context_p, /) -> mtmd_gen_audio_info:
     ...
 
 
+# // defaults tuned for the loaded pipeline, callers override only what they care about
+# MTMD_API struct mtmd_gen_inp mtmd_gen_inp_default(const mtmd_context * ctx);
+@ctypes_function(
+    "mtmd_gen_inp_default",
+    [mtmd_context_p_ctypes],
+    mtmd_gen_inp,
+)
+def mtmd_gen_inp_default(ctx: mtmd_context_p, /) -> mtmd_gen_inp:
+    """Get default audio generation input parameters for an MTMD context."""
+    ...
+
+
 # // note: this API is stateless, caller must handle state management and audio frame accumulation
 # MTMD_API int32_t mtmd_gen_audio_process(mtmd_context * ctx,
 #                                 const struct mtmd_gen_inp * inp,
@@ -1303,12 +1344,15 @@ def mtmd_helper_gen_audio_step_prompt(
 
 
 # // generates one frame; must only be called after step_prompt() has returned 0
-# // h_state_out is valid until next step_gen() or reset() call
+# // sampled can be LLAMA_TOKEN_NULL for pipelines with no discrete backbone token
+# // out_stop (optional) is set on end-of-speech, the caller must then stop the loop
+# // h_state_out is valid until next step_gen() or reset() call, None if no frame is generated
 # MTMD_API int32_t mtmd_helper_gen_audio_step_gen(
 #                         mtmd_helper_gen_audio * ctx,
 #                         llama_token sampled,
 #                         const float *  h_state_in,
-#                         const float ** h_state_out);
+#                         const float ** h_state_out,
+#                         bool * out_stop);
 @ctypes_function(
     "mtmd_helper_gen_audio_step_gen",
     [
@@ -1316,6 +1360,7 @@ def mtmd_helper_gen_audio_step_prompt(
         llama_cpp.llama_token,
         POINTER(c_float),
         POINTER(POINTER(c_float)),
+        POINTER(c_bool),
     ],
     c_int32,
 )
@@ -1324,6 +1369,7 @@ def mtmd_helper_gen_audio_step_gen(
     sampled: llama_cpp.llama_token,
     h_state_in: Optional["_Pointer[c_float]"],
     h_state_out: "_Pointer[_Pointer[c_float]]",
+    out_stop: Optional["_Pointer[c_bool]"],
     /,
 ) -> int:
     """Generate one audio frame."""


### PR DESCRIPTION
Updates the vendored llama.cpp revision and synchronizes its Python bindings.

- Updates llama.cpp to ggml-org/llama.cpp@adb55e514.
- Syncs load mode, context output limits, sampler APIs, and MTMD audio generation bindings.
- Validates the update with a clean native build, ABI layout checks, Ruff, and the full test suite.