### PR TITLE
feat: update llama.cpp to 4df29be4f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat: update llama.cpp to ggml-org/llama.cpp@4df29be4f
 - fix(example): retain recurrent state for server MTP rollback
 - feat: update llama.cpp to ggml-org/llama.cpp@adb55e514
 


### PR DESCRIPTION
Update the vendored llama.cpp submodule to `4df29be4f`.

- Add upstream Kimi K3 text model support.
- Include chat-template capability refactoring and LoRA tensor bounds validation.
- Record the new vendored revision in the changelog.