### PR TITLE
chore: bump version to 0.3.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.35]
+
 - feat: update llama.cpp to ggml-org/llama.cpp@4df29be4f
 - fix(example): retain recurrent state for server MTP rollback
 - feat: update llama.cpp to ggml-org/llama.cpp@adb55e514

--- a/llama_cpp/__init__.py
+++ b/llama_cpp/__init__.py
@@ -1,4 +1,4 @@
 from .llama_cpp import *
 from .llama import *
 
-__version__ = "0.3.34"
+__version__ = "0.3.35"


### PR DESCRIPTION
Prepares the v0.3.35 release.

- Bumps `llama_cpp.__version__` to `0.3.35`.
- Moves the current unreleased changes under the `0.3.35` changelog heading.